### PR TITLE
Validate input configuration against schema

### DIFF
--- a/.github/workflows/fmu-tools.yml
+++ b/.github/workflows/fmu-tools.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['2.7', '3.6', '3.7', '3.8']
+        python-version: ['3.6', '3.7', '3.8']
 
     steps:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ xlrd~=1.2
 fmu-ensemble>=1.2
 libecl>=2.9
 xtgeo>=2.8
+jsonschema>=3.2.0

--- a/src/fmu/tools/_schemas/wellzonation_vs_grid.schema
+++ b/src/fmu/tools/_schemas/wellzonation_vs_grid.schema
@@ -1,0 +1,154 @@
+{
+    "title": "zonelog_vs_grid",
+    "description": "Input configuration for zonelog vs grid method",
+    "required": [
+        "path",
+        "grid",
+        "zone",
+        "wells",
+        "zonelogname",
+        "zonelogrange"
+    ],
+    "$schema": "https://json-schema.org/draft-07/schema",
+    "type": "object",
+    "properties": {
+        "verbosity": {
+            "description": "Log detail level",
+            "type": "string",
+            "examples": [
+                "debug"
+            ]
+        },
+        "path": {
+            "description": "Path to some folder",
+            "type": "string",
+            "examples": [
+                "/path/to/some/folder"
+            ]
+        },
+        "grid": {
+            "description": "Name of grid",
+            "type": "string",
+            "examples": [
+                "mygrid.roff"
+            ]
+        },
+        "zone": {
+            "description": "Name/Path of zone ",
+            "type": "object",
+            "patternProperties": {
+                "^.*$": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        }
+                    ]
+                }
+            }
+        },
+        "wells": {
+            "description": "List of well names",
+            "type": "array",
+            "contains": {
+                "type": "string"
+            }
+        },
+        "zonelogname": {
+            "description": "Name of zonelog",
+            "type": "string",
+            "examples": [
+                "ZONELOG"
+            ]
+        },
+        "zonelogrange": {
+            "description": "Range of zonelog values to use",
+            "type": "array",
+            "items": [
+                {
+                    "type": "number"
+                },
+                {
+                    "type": "number"
+                }
+            ]
+        },
+        "depthrange": {
+            "description": "Range of well trajectory to use",
+            "type": "array",
+            "items": [
+                {
+                    "type": "number"
+                },
+                {
+                    "type": "number"
+                }
+            ]
+        },
+        "actions_each": {
+            "type": "object",
+            "description": "Thresholds for each action",
+            "properties": {
+                "warnthreshold": {
+                    "description": "Values below will raise warning",
+                    "type": "number",
+                    "examples": [
+                        50
+                    ]
+                },
+                "stopthreshold": {
+                    "description": "Values below will halt",
+                    "type": "number",
+                    "examples": [
+                        50
+                    ]
+                }
+            }
+        },
+        "actions_all": {
+            "type": "object",
+            "description": "Threshold for total action",
+            "properties": {
+                "warnthreshold": {
+                    "description": "Values below will raise warning",
+                    "type": "number",
+                    "examples": [
+                        50
+                    ]
+                },
+                "stopthreshold": {
+                    "description": "Values below will halt",
+                    "type": "number",
+                    "examples": [
+                        50
+                    ]
+                }
+            }
+        },
+        "report": {
+            "type": "object",
+            "properties": {
+                "file": {
+                    "type": "string",
+                    "description": "Path to report file",
+                    "examples": [
+                        "/path/to/some/file"
+                    ]
+                },
+                "mode": {
+                    "type": "string",
+                    "enum": [
+                        "write",
+                        "append"
+                    ]
+                }
+            }
+        },
+        "dump_yaml": {
+            "type": "string",
+            "description": "Write configuration to yaml",
+            "examples": [
+                "/path/to/some/file"
+            ]
+        }
+    }
+}

--- a/src/fmu/tools/qcforward/qcforward.py
+++ b/src/fmu/tools/qcforward/qcforward.py
@@ -3,9 +3,12 @@ from __future__ import absolute_import, division, print_function  # PY2
 
 import sys
 from os.path import join
-
-import fmu.tools
+from pathlib import Path
+import json
 import yaml
+
+from jsonschema import validate
+import fmu.tools
 from . import _wellzonation_vs_grid as _wzong
 from . import _grid_statistics as _gstat
 
@@ -108,6 +111,7 @@ class QCForward(object):
 
         self._method = "wellzonation_vs_grid"
         data = self.handle_data(data)
+        validate_input("wellzonation_vs_grid.schema", data)
 
         _wzong.wellzonation_vs_grid(self, data)
 
@@ -117,3 +121,10 @@ class QCForward(object):
         self._method = "grid_statistics"
 
         _gstat.grid_statistics(self, data)
+
+
+def validate_input(schema, data):
+    schemapath = Path(fmu.tools.__file__).parent / "_schemas"
+    with open((schemapath / "wellzonation_vs_grid.schema"), "r") as schemafile:
+        schema = json.load(schemafile)
+    validate(instance=data, schema=schema)

--- a/tests/test_qcforward.py
+++ b/tests/test_qcforward.py
@@ -9,6 +9,7 @@ from fmu.tools import qcforward as qcf
 import pytest
 import pandas as pd
 import xtgeo
+from jsonschema.exceptions import ValidationError
 
 # filedata
 PATH = abspath(".")  # normally not needed; here due to pytest fixture tmpdir
@@ -22,6 +23,25 @@ WELLFILES = [
 
 ZONELOGNAME = "Zonelog"
 REPORT = abspath("./somefile.csv")
+
+
+@pytest.mark.skipif(sys.version_info < (3, 0), reason="requires Python3")
+def test_zonelog_vs_grid_validation():
+    wellcheck = qcf.QCForward()
+
+    data = {
+        "path": PATH,
+        "grid": GRIDFILE,
+        "zone": {ZONENAME: ZONEFILE},
+        "wells": WELLFILES,
+        "zonelogname": ZONELOGNAME,
+        "zonelogrange": [1, 3],  # inclusive range at both ends
+        "depthrange": ["THISISNOTVALIDDEPTH", 9999],
+    }
+    wellcheck = qcf.QCForward()
+
+    with pytest.raises(ValidationError):
+        wellcheck.wellzonation_vs_grid(data)
 
 
 @pytest.mark.skipif(sys.version_info < (3, 0), reason="requires Python3")


### PR DESCRIPTION
Validate user input configuration against predefined [JSON schemas](http://json-schema.org/) for each function (QCForward).
Will raise ValidationError if the provided configuration is invalid. 
E.g. missing required keys or having wrong types.

PR not ready for merge, but mainly meant as an input for discussion around this type of functionality.

Another possibility with this type of validation is to provide end-users with html forms (, e.g. using https://github.com/rjsf-team/react-jsonschema-form, ) instead of YAML files
