### PR TITLE
Support having multiple properties in one file in QCProperties

### DIFF
--- a/docs/qcproperties.rst
+++ b/docs/qcproperties.rst
@@ -114,6 +114,8 @@ Common fields:
         ``name``: The actual name (or path) of the property / log.
     
         ``weight``: A weight parameter (name or path if outside RMS) (optional)
+  
+        ``pfile``: Name (or path) to file containing the parameter e.g. INIT file (optional)
 
     selectors
         Selectors are discrete properties/logs e.g. Zone. that are used to extract
@@ -131,6 +133,8 @@ Common fields:
     
         ``codes``: A dictionary of codenames to update some/all existing codenames (optional). 
 
+        ``pfile``: Name (or path) to file containing the parameter e.g. INIT file (optional)
+
         .. note:: The "codes" field can be used to merge code values that the user wants to extract 
                   combined statistics from. This is done by setting the same name on several code 
                   values, as it is the name that are used to group the data.
@@ -146,6 +150,8 @@ Common fields:
         ``include``: List of values to include (optional)
     
         ``exclude``: List of values to exclude (optional)
+
+        ``pfile``: Name (or path) to file containing the parameter e.g. INIT file (optional)
 
         .. seealso:: Option ``"multiple_filters"`` below which can be used to extract statistics 
                      multiple times with different filters.

--- a/src/fmu/tools/qcproperties/qcproperties.py
+++ b/src/fmu/tools/qcproperties/qcproperties.py
@@ -105,12 +105,10 @@ class QCProperties:
                         if "pfile" in values:
                             pfiles[values["name"]] = values["pfile"]
 
-            data["gridprops"] = []
-            for param in pdata.params:
-                if param in pfiles:
-                    data["gridprops"].append([param, pfiles[param]])
-                else:
-                    data["gridprops"].append(["unknown", param])
+            data["gridprops"] = [
+                [param, pfiles[param]] if param in pfiles else ["unknown", param]
+                for param in pdata.params
+            ]
 
         if qcdata is not None:
             self._xtgdata = qcdata

--- a/src/fmu/tools/qcproperties/qcproperties.py
+++ b/src/fmu/tools/qcproperties/qcproperties.py
@@ -98,7 +98,19 @@ class QCProperties:
         )
 
         if dtype == "grid":
-            data["gridprops"] = pdata.params
+            pfiles = {}
+            for elem in ["properties", "selectors", "filters"]:
+                if elem in data and isinstance(data[elem], dict):
+                    for values in data[elem].values():
+                        if "pfile" in values:
+                            pfiles[values["name"]] = values["pfile"]
+
+            data["gridprops"] = []
+            for param in pdata.params:
+                if param in pfiles:
+                    data["gridprops"].append([param, pfiles[param]])
+                else:
+                    data["gridprops"].append(["unknown", param])
 
         if qcdata is not None:
             self._xtgdata = qcdata

--- a/tests/test_qcproperties/test_qcproperties_grid.py
+++ b/tests/test_qcproperties/test_qcproperties_grid.py
@@ -211,7 +211,7 @@ def test_get_value():
     )
 
 
-def multiple_filters():
+def test_multiple_filters():
     data = data_orig.copy()
     data.pop("selectors", None)
     data["multiple_filters"] = {
@@ -232,4 +232,24 @@ def multiple_filters():
     assert set(["test1", "test2"]) == set(qcp.dataframe["ID"].unique())
     assert qcp.dataframe[
         (qcp.dataframe["PROPERTY"] == "PORO") & (qcp.dataframe["ID"] == "test1")
-    ].values == pytest.approx(0.1155, abs=0.001)
+    ]["Avg"].values == pytest.approx(0.1183, abs=0.001)
+
+
+def test_read_eclipse():
+    data = data_orig.copy()
+    data["grid"] = "REEK.EGRID"
+    data["properties"] = {
+        "PORO": {"name": "PORO", "pfile": "REEK.INIT"},
+        "PERM": {"name": "PERMX", "pfile": "REEK.INIT"},
+    }
+    data["selectors"] = {
+        "REGION": {"name": "FIPNUM", "pfile": "REEK.INIT"},
+    }
+
+    qcp = QCProperties()
+    qcp.get_grid_statistics(data)
+
+    assert set(["REEK"]) == set(qcp.dataframe["ID"].unique())
+    assert qcp.dataframe[
+        (qcp.dataframe["PROPERTY"] == "PORO") & (qcp.dataframe["REGION"] == "2")
+    ]["Avg"].values == pytest.approx(0.1661, abs=0.001)


### PR DESCRIPTION
Added an optional 'pfile' argument for parameters. Needed if multiple properties are located in one file e.g. for reading INIT files. 