### PR TITLE
bug fix for properties without code names

### DIFF
--- a/src/fmu/tools/qcproperties/_propstat.py
+++ b/src/fmu/tools/qcproperties/_propstat.py
@@ -202,6 +202,13 @@ class PropStat:
                         f"{param} parameter is not!"
                     )
                 codes = xtg_prop.codes.copy()
+
+                # if no codenames, use codevalues as codenames
+                if not codes:
+                    codes = {
+                        value: str(value)
+                        for value in np.unique(xtg_prop.get_active_npvalues1d())
+                    }
             else:
                 codes = self._wells[0].get_logrecord(param).copy()
 

--- a/src/fmu/tools/qcproperties/_propstat_parameter_data.py
+++ b/src/fmu/tools/qcproperties/_propstat_parameter_data.py
@@ -69,9 +69,10 @@ class PropStatParameterData:
         self._properties, self._selectors = self._input_conversion(
             properties, selectors
         )
-
         # combine data and set different instance attributes
         self._combine_data(filters)
+
+        self._filter_values_to_string()
 
     @property
     def properties(self):
@@ -200,3 +201,14 @@ class PropStatParameterData:
         QCC.print_debug(f"All Properties: {self.properties}")
         QCC.print_debug(f"All Selectors: {self.selectors}")
         QCC.print_debug(f"All Filters: {self.filters}")
+
+    def _filter_values_to_string(self):
+        """
+        String convertion of filter list values to support using integers as input.
+        Useful for properties with code values as code names.
+        """
+        for prop, values in self._filters.items():
+            if "include" in values:
+                self._filters[prop] = {"include": [str(x) for x in values["include"]]}
+            if "exclude" in values:
+                self._filters[prop] = {"exclude": [str(x) for x in values["exclude"]]}

--- a/src/fmu/tools/qcproperties/_propstat_parameter_data.py
+++ b/src/fmu/tools/qcproperties/_propstat_parameter_data.py
@@ -208,7 +208,6 @@ class PropStatParameterData:
         Useful for properties with code values as code names.
         """
         for prop, values in self._filters.items():
-            if "include" in values:
-                self._filters[prop] = {"include": [str(x) for x in values["include"]]}
-            if "exclude" in values:
-                self._filters[prop] = {"exclude": [str(x) for x in values["exclude"]]}
+            for filtstr in ["include", "exclude"]:
+                if filtstr in values and isinstance(values[filtstr], list):
+                    self._filters[prop] = {filtstr: [str(x) for x in values[filtstr]]}


### PR DESCRIPTION
XTGeo gave an empty dictionary as output for code names for properties that did not have any. This caused a bug when trying to replace codes in dicrete parameters with code names. 

As a bug fix the code values are used as code names for relevant properties.
(Note, the issue has been fixed in XTGeo now)

Also added support for using values as input in filter list