### PR TITLE
Change column name PORE_x to PORV_x in volumetrics

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,6 @@ ignore = E203, W503
 test = pytest
 
 [tool:pytest]
-addopts = --verbose -x
 markers =
     integration: marks a test as an integration test
     skipunlessroxar: skip this test unless Roxar license

--- a/src/fmu/tools/rms/volumetrics.py
+++ b/src/fmu/tools/rms/volumetrics.py
@@ -78,7 +78,7 @@ def rmsvolumetrics_txt2df(
         "Bulk": "BULK_" + phase,
         "Net": "NET_" + phase,
         "Hcpv": "HCPV_" + phase,
-        "Pore": "PORE_" + phase,
+        "Pore": "PORV_" + phase,
         "Stoiip": "STOIIP_" + phase,
         "Giip": "GIIP_" + phase,
         "Assoc.Liquid": "ASSOCIATEDOIL_" + phase,


### PR DESCRIPTION
This is a bugfix, the previous column name was not according
to the defined standard.

Solves #130 