### PR TITLE
Support integer inputs to fipmapper for reg/zone

### DIFF
--- a/src/fmu/tools/fipmapper/fipmapper.py
+++ b/src/fmu/tools/fipmapper/fipmapper.py
@@ -103,6 +103,15 @@ class FipMapper:
         self.has_region2fip = "region2fipnum" in self._mapdata
         self.has_zone2fip = "zone2fipnum" in self._mapdata
 
+        # Validate that all FIPNUMs are integers:
+        try:
+            [int(fip) for fip in self.get_fipnums()]
+        except AssertionError:
+            # This is for partially empty fipmappers.
+            pass
+        except ValueError:
+            raise TypeError(f"All FIPNUMs must be integers, got {self.get_fipnums}")
+
     def _get_explicit_mapdata(self, yamldata: Dict[str, Any]):
         """Fetch explicit mapping configuration from a dictionary.
 

--- a/src/fmu/tools/fipmapper/fipmapper.py
+++ b/src/fmu/tools/fipmapper/fipmapper.py
@@ -47,6 +47,15 @@ class FipMapper:
             * A zone is assumed to be present for all regions, but not
               relevant in this class
 
+        For FIPNUM, the datatype must be integers, but can be initialized
+        from strings as long as they can be parsed as strings.
+
+        For Region and Zone, a string datatype is assumed, but the yaml
+        input is allowed to be integers or integers and strings mixed. Some
+        functions will return these as integers if they were inputted as such,
+        but at least the disjoint_sets() function will always return
+        these as strings.
+
         Args:
             yamlfile: Filename
             mapdata: direct dictionary input. Provide only one of the
@@ -178,6 +187,7 @@ class FipMapper:
         try:
             return sorted(self._mapdata["region2fipnum"].keys())
         except TypeError:
+            # We get here if some regions are ints and others are strings
             return sorted(map(str, self._mapdata["region2fipnum"].keys()))
 
     def get_zones(self) -> List[str]:
@@ -186,17 +196,15 @@ class FipMapper:
         try:
             return sorted(self._mapdata["zone2fipnum"].keys())
         except TypeError:
+            # We get here if some zones are ints and others are strings
             return sorted(map(str, self._mapdata["zone2fipnum"].keys()))
 
     def get_fipnums(self) -> List[str]:
         """Obtain a sorted list of the fip numbers that exist in the map"""
         assert "fipnum2region" in self._mapdata, "No data provided for regions"
-        try:
-            return sorted(self._mapdata["fipnum2region"].keys())
-        except TypeError:
-            return sorted(map(str, self._mapdata["fipnum2region"].keys()))
+        return sorted(self._mapdata["fipnum2region"].keys())
 
-    def fip2region(self, fip: Optional[int]) -> List[str]:
+    def fip2region(self, fip: int) -> List[str]:
         """Maps one FIP(NUM) integer to list of Region strings. Each FIPNUM
         can map to multiple regions, therefore a list is always returned for
         each FIPNUM.
@@ -252,9 +260,6 @@ class FipMapper:
                 return [int(fips)]
             return [int(fip) for fip in fips]
         except KeyError:
-            import pdb
-
-            pdb.set_trace()
             logger.warning(
                 "Unknown region %s, known map is %s",
                 str(region),

--- a/src/fmu/tools/rms/volumetrics.py
+++ b/src/fmu/tools/rms/volumetrics.py
@@ -50,6 +50,7 @@ def _find_volumetrics_files(filebase: str, rmsrealsuffix: str) -> List[Path]:
 
     for phase in phases_to_look_for:
         filecandidate = Path(filebase + "_" + phase + rmsrealsuffix + ".txt")
+        print(filecandidate)
         if filecandidate.exists():
             filesfound.append(filecandidate)
 

--- a/src/fmu/tools/rms/volumetrics.py
+++ b/src/fmu/tools/rms/volumetrics.py
@@ -50,7 +50,6 @@ def _find_volumetrics_files(filebase: str, rmsrealsuffix: str) -> List[Path]:
 
     for phase in phases_to_look_for:
         filecandidate = Path(filebase + "_" + phase + rmsrealsuffix + ".txt")
-        print(filecandidate)
         if filecandidate.exists():
             filesfound.append(filecandidate)
 

--- a/tests/fipmapper/test_disjointsets.py
+++ b/tests/fipmapper/test_disjointsets.py
@@ -106,6 +106,11 @@ import pandas as pd
             [{"REGION": "A", "ZONE": "U", "FIPNUM": 1, "SET": 0}],
         ),
         (
+            # Same as above, but with integer regions and zone:
+            {"region2fipnum": {1: 1}, "zone2fipnum": {1: 1}},
+            [{"REGION": "1", "ZONE": "1", "FIPNUM": 1, "SET": 0}],
+        ),
+        (
             # FIPNUM split in two, gives only one group in return:
             {"region2fipnum": {"A": [1, 2]}, "zone2fipnum": {"U": [1, 2]}},
             [
@@ -187,6 +192,34 @@ import pandas as pd
                 {"REGION": "A", "ZONE": "U", "FIPNUM": 1, "SET": 0},
                 {"REGION": "B", "ZONE": "U", "FIPNUM": 1, "SET": 0},
                 {"REGION": "B", "ZONE": "U", "FIPNUM": 2, "SET": 0},
+            ],
+        ),
+        (
+            # Integer datatypes for regions and zones, always
+            # strings in returned dataframe, even though
+            # FipMapper handles the integers as ints internally
+            {
+                "region2fipnum": {1: 1, 2: 2},
+                "zone2fipnum": {1: [1, 2], 2: [1, 2]},
+            },
+            [
+                {"REGION": "1", "ZONE": "1", "FIPNUM": 1, "SET": 0},
+                {"REGION": "1", "ZONE": "2", "FIPNUM": 1, "SET": 0},
+                {"REGION": "2", "ZONE": "1", "FIPNUM": 2, "SET": 1},
+                {"REGION": "2", "ZONE": "2", "FIPNUM": 2, "SET": 1},
+            ],
+        ),
+        (
+            # Mixed datatype int/str for regions and zones
+            {
+                "region2fipnum": {1: 1, "B": 2},
+                "zone2fipnum": {"U": [1, 2], 2: [1, 2]},
+            },
+            [
+                {"REGION": "1", "ZONE": "2", "FIPNUM": 1, "SET": 0},
+                {"REGION": "1", "ZONE": "U", "FIPNUM": 1, "SET": 0},
+                {"REGION": "B", "ZONE": "2", "FIPNUM": 2, "SET": 1},
+                {"REGION": "B", "ZONE": "U", "FIPNUM": 2, "SET": 1},
             ],
         ),
     ],

--- a/tests/fipmapper/test_fipmapper.py
+++ b/tests/fipmapper/test_fipmapper.py
@@ -73,6 +73,42 @@ def test_fipmapper_zones():
     assert mapper.zone2fip("Middle") == [2, 3]
 
 
+def test_integer_regions():
+    """Regions are sometimes integer, and then they will
+    typically be returned as integers from the yaml parsing"""
+    mapper = fipmapper.FipMapper(mapdata={"fipnum2region": {1: 1, 2: 2}})
+    assert mapper.fip2region(1) == [1]
+    assert mapper.fip2region(2) == [2]
+    assert mapper.region2fip(1) == [1]
+    assert mapper.region2fip(2) == [2]
+
+
+def test_integer_zones():
+    """Should also allow using integers for zones. Maybe
+    the integer is actually the k index"""
+    mapper = fipmapper.FipMapper(mapdata={"fipnum2zone": {1: 1, 2: 2}})
+    assert mapper.fip2zone(1) == [1]
+    assert mapper.fip2zone(2) == [2]
+    assert mapper.zone2fip(1) == [1]
+    assert mapper.zone2fip(2) == [2]
+
+
+def test_mixed_datatypes():
+    """Mixed ints/strs in regions and zones"""
+    mapper = fipmapper.FipMapper(
+        mapdata={"fipnum2region": {1: 1, 2: "B"}, "fipnum2zone": {1: 1, 2: "L"}}
+    )
+    assert mapper.fip2region(1) == [1]
+    assert mapper.fip2region(2) == ["B"]
+    assert mapper.region2fip(1) == [1]
+    assert mapper.region2fip("B") == [2]
+
+    assert mapper.fip2zone(1) == [1]
+    assert mapper.fip2zone(2) == ["L"]
+    assert mapper.zone2fip(1) == [1]
+    assert mapper.zone2fip("L") == [2]
+
+
 def test_fipmapper_regzone2fip():
     mapper = fipmapper.FipMapper(
         mapdata={
@@ -107,6 +143,13 @@ def test_fipmapper_regzone2fip():
             ["A"],
             ["U"],
             [1, 2],
+        ),
+        (
+            # Test sorting with integer regions
+            {"region2fipnum": {10: [3], 1: [2, 1]}, "zone2fipnum": {"U": [2, 1, 3]}},
+            [1, 10],
+            ["U"],
+            [1, 2, 3],
         ),
         (
             {

--- a/tests/fipmapper/test_fipmapper.py
+++ b/tests/fipmapper/test_fipmapper.py
@@ -177,6 +177,13 @@ def test_fipmapper_regzone2fip():
             # get_regions fails here.
             marks=pytest.mark.xfail(raises=AssertionError),
         ),
+        pytest.param(
+            {"zone2fipnum": {"U": "fip1"}, "region2fipnum": {"W": "fip1"}},
+            ["W"],
+            ["U"],
+            ["fip1"],
+            marks=pytest.mark.xfail(raises=TypeError),
+        ),
     ],
 )
 def test_get_regions_zones_fipnums(


### PR DESCRIPTION
The return type of disjoint_sets() is always
strings for regions and zones, but other functions in
fipmapper try to conserve the datatype obtained from
the yaml parsing.

Keeping integers as ints is done in order to facilitate
sorting of regions and zones.