### PR TITLE
Avoid `xtgeo` prerelease dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ pandas>=0.21
 pyyaml>=5.3
 scipy>=1.2
 xlrd>=1.2
-xtgeo>=2.15a2
+xtgeo>=2.15
 jsonschema>=3.2.0


### PR DESCRIPTION
Using prerelease lower bound in `fmu-tools` requirements apparently open up for downstream packages getting prereleases installed (even though they haven't asked for prereleases with `--pre` AND there are new official releases of the dependency satisfying the requirement 🤔).