### PR TITLE
Add rmsimport

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,6 +13,7 @@ Contents:
    qcproperties
    qcreset
    create_rft_ertobs
+   rms_import_localmodule
    rmsvolumetrics2csv
    ensembles
    contributing

--- a/docs/rms_import_localmodule.rst
+++ b/docs/rms_import_localmodule.rst
@@ -1,0 +1,22 @@
+rms.import_localmodule
+======================
+
+Inside the RMS project it can be beneficial to have a module that serves as a library,
+not only a front end script. Several problems exist in current RMS
+
+* RMS has no awareness of this 'PYTHONPATH', i.e. <project>/pythoncomp
+* RMS will, once loaded, not refresh any changes made in the module
+* Python requires extension .py, but RMS often adds .py_1 for technical reasons,
+  which makes it impossible for the end-user to understand why it will not work,
+  as the 'instance-name' (script name inside RMS) and the actual file name will
+  differ.
+
+This function solves all these issues, and makes it possible to import a RMS project
+library in a much easier way::
+
+    import fmu.tools as tools
+
+    # mylib.py is inside the RMS project
+    plib = tools.rms.import_localmodule(project, "mylib")
+
+    plib.somefunction(some_arg)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,11 +20,12 @@ profile = "black"
 
 [build-system]
 requires = [
-    "pip>=19.1.1",
-    "setuptools>=30.3.0",
-    "setuptools_scm>=3.2.0",
-    "wheel",
-    "sphinx",
-    "sphinx-rtd-theme",
-    "sphinxcontrib-apidoc",
+  "pip>=19.1.1",
+  "setuptools>=30.3.0",
+  "setuptools_scm>=3.2.0",
+  "wheel",
+  "sphinx==5.3",
+  "docutils==0.16",
+  "sphinx-rtd-theme",
+  "sphinxcontrib-apidoc",
 ]

--- a/src/fmu/tools/rms/__init__.py
+++ b/src/fmu/tools/rms/__init__.py
@@ -3,5 +3,7 @@ Processing of volumetrics from RMS
 """
 
 from .volumetrics import rmsvolumetrics_txt2df
+from .import_localmodule import import_localmodule
+
 
 __all__ = ["rmsvolumetrics_txt2df"]

--- a/src/fmu/tools/rms/import_localmodule.py
+++ b/src/fmu/tools/rms/import_localmodule.py
@@ -1,0 +1,106 @@
+"""Import a local module made inside RMS, and refresh the content."""
+
+import importlib
+import logging
+import shutil
+import sys
+import tempfile
+import warnings
+from os.path import join
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+def _detect_pyfile(path, module_root_name):
+    """A module shall be named *.py, but may have different 'actual' name in RMS.
+
+    Returns:
+        actual_file: e.g. mymodule_name_ondisk.py_1
+        module: e.g. name_seen_in_rms.py
+    """
+
+    usepath = Path(path)
+    proposed = [
+        usepath / (module_root_name + ".py"),
+        usepath / (module_root_name + ".py_1"),
+        usepath / (module_root_name + ".py_2"),
+        usepath / (module_root_name),
+    ]
+
+    for proposal in proposed:
+        logger.info("Look for %s", proposal)
+        if proposal.is_file():
+            logger.info("-> Found %s", proposal)
+            if not ".py" in proposal.name:
+                warnings.warn(
+                    "Warning: Please avoid modules without a .py ending!", UserWarning
+                )
+            return proposal, module_root_name + ".py"
+
+    return None, None
+
+
+def import_localmodule(project, module_root_name):
+    """Import a library module in RMS which exists inside the RMS project.
+
+    Inside a RMS project it can be beneficial to have a module that serves as a library,
+    not only a front end script. Several problems exist in current RMS:
+
+        - RMS has no awareness of this 'PYTHONPATH', i.e. <project>/pythoncomp
+        - RMS will, once loaded, not refresh any changes made in the module
+        - Python requires extension .py, but RMS often adds .py_1 for technical reasons,
+          which makes it impossible for the end-user to understand why it will not work,
+          as the 'instance-name' (script name inside RMS) and the actual file name will
+          differ.
+
+    This function solves all these issues, and makes it possible to import a RMS project
+    library in a much easier way::
+
+        import fmu.tools as tools
+
+        # mylib.py is inside the RMS project
+        plib = tools.rms.import_localmodule(project, "mylib")
+
+        plib.somefunction(some_arg)
+
+    Args:
+        project: RMS 'magic' project variable
+        module_root_name: A string that is the root name of your module. E.g. if
+            the module is named 'blah.py', the use 'blah'.
+
+
+    """
+    if isinstance(project, str):
+        # allow project to be a string; mostly for unit testing
+        prj = project
+    else:
+        try:
+            prj = project.filename
+        except AttributeError as err:
+            raise RuntimeError(f"The project object is invalid: {err}")
+
+    mypath = prj + "/pythoncomp"
+
+    actualfile, module = _detect_pyfile(mypath, module_root_name)
+
+    if not actualfile:
+        raise ValueError(f"Cannot detect module {module_root_name}. Check spelling etc")
+
+    # Now empty sys.path for this module, allowing a refresh when library is modified:
+    sysm = sys.modules.copy()
+    for key, val in sysm.items():
+        if module in str(val):
+            logger.info("Delete from modules: %s", key)
+            del sys.modules[key]
+
+    # since modules in RMS may have invalid endings; copy to a tempfile instead
+    # with correct name, and let that part be in sys.path temporarily
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        sys.path.insert(0, tmpdirname)
+        fname = shutil.copy(actualfile, join(tmpdirname, module))
+        logger.info("Using tmp file: %s", fname)
+
+        xmod = importlib.import_module(module_root_name)
+        sys.path.pop(0)  # avoid accumulation in sys.path by removing tmppath from stack
+        return xmod

--- a/tests/rms/test_import_localmodule.py
+++ b/tests/rms/test_import_localmodule.py
@@ -1,0 +1,67 @@
+"""Test code for rms local module function."""
+import os
+import fmu.tools
+import pytest
+
+SNIPPET1 = """
+def add(a, b):
+    return(a + b)
+
+def say_hello(name):
+    return(f"Hello {name}")
+"""
+
+
+@pytest.mark.parametrize(
+    "modulename, shall_fail",
+    [
+        ("mymod.py", False),
+        ("mymod.py_1", False),
+        ("mymod", False),
+        ("invalid_name", True),
+    ],
+)
+def test_rms_import_localmodule(tmp_path, modulename, shall_fail):
+    """Test import of a module via rms.import_localmodule."""
+
+    pycomp = tmp_path / "myproject" / "pythoncomp"
+    print(pycomp)
+    pycomp.mkdir(parents=True)
+
+    os.chdir(pycomp)
+    with open(modulename, "w") as stream:
+        stream.write(SNIPPET1)
+    os.chdir(pycomp.parent)
+
+    fake_project = os.getcwd()
+
+    if not shall_fail:
+        mylib = fmu.tools.rms.import_localmodule(fake_project, "mymod")
+        id1 = id(mylib)
+
+        assert mylib.add(3, 4) == 7
+        assert mylib.say_hello("world") == "Hello world"
+
+        id1 = id(mylib)
+        id2 = id(fmu.tools.rms.import_localmodule(fake_project, "mymod"))
+        assert id1 != id2
+    else:
+        with pytest.raises(ValueError, match="Cannot detect module"):
+            mylib = fmu.tools.rms.import_localmodule(fake_project, "mymod")
+
+
+def test_rms_import_invalid_name(tmp_path):
+    """Test import of a module that is invalid."""
+
+    pycomp = tmp_path / "myproject" / "pythoncomp"
+    print(pycomp)
+    pycomp.mkdir(parents=True)
+
+    os.chdir(pycomp)
+    with open("mymod.py", "w") as stream:
+        stream.write(SNIPPET1)
+    os.chdir(pycomp.parent)
+
+    fake_project = object()
+    with pytest.raises(Exception, match=r"The project object is invalid"):
+        mylib = fmu.tools.rms.import_localmodule(fake_project, "mymod")


### PR DESCRIPTION
Inside RMS: Make it possible to load an internal module and solve some challenges (behind the curtain) that RMS has:
* Automatically add rmsproject/pythoncomp to `sys.path`
* Make it possible to edit a library module in RMS and the module import will auto-refresh
* Solve various issues with actual python extension inside RMS (e.g. `some.py_1`)

Say that "mylib.py" is a local library inside the RMS project:

```
import fmu.tools as ftools
mymodule = ftools.rms.import_localmodule(project, "mylib")
mymodule.somefunction(...)

```