### PR TITLE
fix bug for uncorrelated symmetric pert distrbutions

### DIFF
--- a/src/fmu/tools/sensitivities/design_distributions.py
+++ b/src/fmu/tools/sensitivities/design_distributions.py
@@ -363,7 +363,7 @@ def draw_values_pert(dist_parameters, numreals, normalscoresamples=None):
                 distribution = scipy.stats.uniform(loc=low, scale=0)
             else:
                 muval = (low + high + scale * mode) / (scale + 2)
-                if muval == mode:
+                if numpy.isclose(muval, mode):
                     alpha1 = (scale / 2) + 1
                 else:
                     alpha1 = ((muval - low) * (2 * mode - low - high)) / (


### PR DESCRIPTION
This bug was fixed for correlated pert distributions earlier, but was not changed for correlated pert distribution. Identical fix for these.