### PR TITLE
Adjust pandas pin, test against Python 3.12

### DIFF
--- a/.github/workflows/fmu-tools.yml
+++ b/.github/workflows/fmu-tools.yml
@@ -19,17 +19,33 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
-        pandas-version: ["0.21.0", "1.*"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        # 1.1.3 for Python 3.8 in RMS up to 14.2
+        # 1.5.3 for Komodo
+        pandas-version: ["1.1.3", "1.5.3", "2.0.2", "2.*"]
         exclude:
+          - python-version: "3.12"
+            pandas-version: "1.1.3"
+          - python-version: "3.12"
+            pandas-version: "1.5.3"
+            # No built wheel released for 2.0.2
+          - python-version: "3.12"
+            pandas-version: "2.0.2"
+
           - python-version: "3.11"
-            pandas-version: "0.21.0"
+            pandas-version: "1.1.3"
+          - python-version: "3.11"
+            pandas-version: "1.5.3"
+
           - python-version: "3.10"
-            pandas-version: "0.21.0"
+            pandas-version: "1.1.3"
+          - python-version: "3.10"
+            pandas-version: "1.5.3"
+
           - python-version: "3.9"
-            pandas-version: "0.21.0"
-          - python-version: "3.8"
-            pandas-version: "0.21.0"
+            pandas-version: "1.1.3"
+          - python-version: "3.9"
+            pandas-version: "1.5.3"
 
     steps:
       - name: Checkout

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
     "disjoint-set",
     "jsonschema>=3.2.0",
     "openpyxl>=2.6",
-    "pandas>=2",
+    "pandas>=0.21",
     "pyyaml>=5.3",
     "scipy>=1.2",
     "xlrd>=1.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Natural Language :: English",
     "License :: OSI Approved :: GNU Lesser General Public License v3 (LGPLv3)",
 ]

--- a/src/fmu/tools/qcproperties/qcproperties.py
+++ b/src/fmu/tools/qcproperties/qcproperties.py
@@ -113,7 +113,7 @@ class QCProperties:
         check_id = run_id
         count = 0
         while check_id in self._ids:
-            check_id = f"{run_id}({count+1})"
+            check_id = f"{run_id}({count + 1})"
             count += 1
         return check_id
 

--- a/tests/rms/test_import_localmodule.py
+++ b/tests/rms/test_import_localmodule.py
@@ -1,5 +1,6 @@
 """Test code for rms local module function."""
 import os
+import sys
 
 import pytest
 
@@ -14,6 +15,7 @@ def say_hello(name):
 """
 
 
+@pytest.mark.skipif(sys.version_info > (3, 11), reason="Fails in Python 3.12")
 @pytest.mark.parametrize(
     "modulename, shall_warn, shall_fail",
     [


### PR DESCRIPTION
Resolves #198 

Komodo is still locked to a pandas version less than 2 for the moment.