### PR TITLE
CI: Add script for running tests from github worklow

### DIFF
--- a/ci/testrmsenv.sh
+++ b/ci/testrmsenv.sh
@@ -1,0 +1,26 @@
+# This shell script is to be sourced and run from a github workflow
+# when fmu-tools is to be tested towards a new RMS enviroment
+
+run_tests () {
+    copy_test_files
+
+    install_test_dependencies
+
+    pushd $CI_TEST_ROOT
+    start_tests
+    popd
+}
+
+install_test_dependencies () {
+    pip install ".[dev]"
+}
+
+copy_test_files () {
+    cp -r $CI_SOURCE_ROOT/tests $CI_TEST_ROOT/tests
+    # Pytest configuration is in pyproject.toml
+    cp $CI_SOURCE_ROOT/pyproject.toml $CI_TEST_ROOT
+}
+
+start_tests () {
+    pytest
+}


### PR DESCRIPTION
Added as a part of issue https://github.com/equinor/rms-sys/issues/267.

Add a new bash script `testrmsenv.sh` that installs fmu-tools and its dependencies and runs its tests.
The shell script will be called by a github workflow when fmu-tools is to be tested towards a new RMS environment. 