### PR TITLE
CI: Add script for running tests from github worklow

### DIFF
--- a/ci/testrmsenv.sh
+++ b/ci/testrmsenv.sh
@@ -12,15 +12,18 @@ run_tests () {
 }
 
 install_test_dependencies () {
-    pip install ".[dev]"
+    echo "Installing test dependencies..."
+    pip install ".[tests]"
 }
 
 copy_test_files () {
+    echo "Copy test files to test folder $CI_TEST_ROOT..."
     cp -r $CI_SOURCE_ROOT/tests $CI_TEST_ROOT/tests
     # Pytest configuration is in pyproject.toml
     cp $CI_SOURCE_ROOT/pyproject.toml $CI_TEST_ROOT
 }
 
 start_tests () {
+    echo "Running fmu-tools tests with pytest..."
     pytest
 }

--- a/ci/testrmsenv.sh
+++ b/ci/testrmsenv.sh
@@ -1,0 +1,26 @@
+# This shell script is to be sourced and run from a github workflow
+# when fmu-tools is to be tested towards a new RMS enviroment
+
+run_tests () {
+    copy_test_files
+
+    install_test_dependencies
+
+    pushd $CI_TEST_ROOT
+    start_tests
+    popd
+}
+
+install_test_dependencies () {
+    pip install ".[dev]"
+}
+
+copy_test_files () {
+    cp -r $CI_SOURCE_ROOT/tests $CI_TEST_ROOT/tests
+    # Pytest configuration is in pyproject.toml
+    cp $CI_SOURCE_ROOT/pyproject.toml $CI_TEST_ROOT
+}
+
+start_tests () {
+    pytest
+}

--- a/ci/testrmsenv.sh
+++ b/ci/testrmsenv.sh
@@ -42,6 +42,6 @@ install_test_dependencies () {
 run_pytest () {
     echo "Running fmu-tools tests with pytest..."
     pushd $CI_TEST_ROOT
-    pytest -n 4 -vv -m "not skipunlessroxar"
+    pytest -n 4 -vv
     popd
 }

--- a/ci/testrmsenv.sh
+++ b/ci/testrmsenv.sh
@@ -17,17 +17,9 @@ set_test_variables() {
 }
 
 copy_test_files () {
-    echo "Copy xtgeo testdata for xtgeo related tests..."
-    if ! [ -d $XTGEO_TESTDATA_PATH ]; then
-        echo "Cloning xtgeo-testdata to $XTGEO_TESTDATA_PATH..."
-        git clone --depth=1 https://github.com/equinor/xtgeo-testdata $XTGEO_TESTDATA_PATH
-    else
-        echo "xtgeo testdata already exists at path $XTGEO_TESTDATA_PATH. Skipping copy."
-    fi
-
     echo "Copy fmu-tools test files to test folder $CI_TEST_ROOT..."
     mkdir -p $CI_TEST_ROOT  
-    cp -r $PROJECT_ROOT/tests $CI_TEST_ROOT/tests
+    cp -r $PROJECT_ROOT/tests $CI_TEST_ROOT
     cp $PROJECT_ROOT/pyproject.toml $CI_TEST_ROOT
 }
 
@@ -42,6 +34,6 @@ install_test_dependencies () {
 run_pytest () {
     echo "Running fmu-tools tests with pytest..."
     pushd $CI_TEST_ROOT
-    pytest -n 4 -vv
+    pytest ./tests -n 4 -vv --testdatapath $XTGEO_TESTDATA_PATH
     popd
 }

--- a/ci/testrmsenv.sh
+++ b/ci/testrmsenv.sh
@@ -1,29 +1,47 @@
 # This shell script is to be sourced and run from a github workflow
-# when fmu-tools is to be tested towards a new RMS enviroment
+# when fmu-tools is to be tested towards a new RMS Python enviroment
 
 run_tests () {
+    set_test_variables
+
     copy_test_files
 
     install_test_dependencies
 
-    pushd $CI_TEST_ROOT
-    start_tests
-    popd
+    run_pytest
+}
+
+set_test_variables() {
+    echo "Setting variables for xtgeo tests..."
+    CI_TEST_ROOT=$CI_ROOT/fmutools-test-root
+}
+
+copy_test_files () {
+    echo "Copy xtgeo testdata for xtgeo related tests..."
+    if ! [ -d $XTGEO_TESTDATA_PATH ]; then
+        echo "Cloning xtgeo-testdata to $XTGEO_TESTDATA_PATH..."
+        git clone --depth=1 https://github.com/equinor/xtgeo-testdata $XTGEO_TESTDATA_PATH
+    else
+        echo "xtgeo testdata already exists at path $XTGEO_TESTDATA_PATH. Skipping copy."
+    fi
+
+    echo "Copy fmu-tools test files to test folder $CI_TEST_ROOT..."
+    mkdir -p $CI_TEST_ROOT  
+    cp -r $PROJECT_ROOT/tests $CI_TEST_ROOT/tests
+    cp $PROJECT_ROOT/pyproject.toml $CI_TEST_ROOT
 }
 
 install_test_dependencies () {
     echo "Installing test dependencies..."
     pip install ".[tests]"
+
+    echo "Dependencies installed successfully. Listing installed dependencies..."
+    pip list
 }
 
-copy_test_files () {
-    echo "Copy test files to test folder $CI_TEST_ROOT..."
-    cp -r $CI_SOURCE_ROOT/tests $CI_TEST_ROOT/tests
-    # Pytest configuration is in pyproject.toml
-    cp $CI_SOURCE_ROOT/pyproject.toml $CI_TEST_ROOT
-}
-
-start_tests () {
+run_pytest () {
     echo "Running fmu-tools tests with pytest..."
-    pytest
+    pushd $CI_TEST_ROOT
+    pytest -n 4 -vv -m "not skipunlessroxar"
+    popd
 }

--- a/tests/properties/test_swfunction.py
+++ b/tests/properties/test_swfunction.py
@@ -2,19 +2,12 @@
 
 # for tests vs RMS cf /private/jriv/work/testing/swfunc/test_swfunc.rms13.1.2
 import math
-from pathlib import Path
 
 import numpy as np
 import pytest
 import xtgeo
 
 from fmu.tools.properties import SwFunction
-
-TPATH = Path("../xtgeo-testdata")
-
-GRIDDATA1 = TPATH / "3dgrids/reek/reek_sim_grid.roff"
-PORODATA1 = TPATH / "3dgrids/reek/reek_sim_poro.roff"
-PERMDATA1 = TPATH / "3dgrids/reek/reek_sim_permx.roff"
 
 
 @pytest.mark.parametrize(
@@ -104,16 +97,20 @@ def test_swj_simple_threshold_2grids():
         (False, "cell_corners_above_ffl", 0.674485, 0.046791),  # n/a vs RMS
     ],
 )
-def test_swj_simple_reek(direct, cellmethod, expected_mean, exp_cell1):
+def test_swj_simple_reek(direct, cellmethod, expected_mean, exp_cell1, testdata_path):
     """Test a simple SwJ setup, expected mean are checked with RMS Sw job"""
+
+    griddata1 = testdata_path / "3dgrids/reek/reek_sim_grid.roff"
+    porodata1 = testdata_path / "3dgrids/reek/reek_sim_poro.roff"
+    permdata1 = testdata_path / "3dgrids/reek/reek_sim_permx.roff"
 
     avalue = 1
     bvalue = -0.5
     ffl = 1700
 
-    grid = xtgeo.grid_from_file(GRIDDATA1)
-    poro = xtgeo.gridproperty_from_file(PORODATA1)
-    perm = xtgeo.gridproperty_from_file(PERMDATA1)
+    grid = xtgeo.grid_from_file(griddata1)
+    poro = xtgeo.gridproperty_from_file(porodata1)
+    perm = xtgeo.gridproperty_from_file(permdata1)
 
     xval = perm.copy()
 

--- a/tests/qcforward/test_bw_vs_gridprops.py
+++ b/tests/qcforward/test_bw_vs_gridprops.py
@@ -10,24 +10,22 @@ from fmu.tools import qcforward as qcf
 
 # filedata
 PATH = abspath(".")  # normally not needed; here due to pytest fixture tmpdir
-GRIDFILE = "../xtgeo-testdata/3dgrids/drogon/3/valysar.roff"
-BWELLFILES = [
-    "../xtgeo-testdata/wells/drogon/3/valysar*.bw",
-]
 COMPARE = {"Facies": "FACIES", "PHIT": "PHIT"}
 
 
 @pytest.fixture(name="datainput")
-def fixture_datainput(tmp_path):
+def fixture_datainput(tmp_path, testdata_path):
+    gridfile = str(testdata_path / "3dgrids/drogon/3/valysar.roff")
+    bwellfiles = [str(testdata_path / "wells/drogon/3/valysar*.bw")]
     return {
         "nametag": "MYDATA1",
         "verbosity": "info",
         "path": PATH,
-        "grid": GRIDFILE,
+        "grid": gridfile,
         "report": tmp_path / "bw_vs_gprop.csv",
         "compare": COMPARE,
-        "gridprops": [["FACIES", GRIDFILE], ["PHIT", GRIDFILE]],
-        "bwells": BWELLFILES,
+        "gridprops": [["FACIES", gridfile], ["PHIT", gridfile]],
+        "bwells": bwellfiles,
         "tolerance": 0.01,
         "actions": [
             {"warn": "anywell < 80%", "stop": "anywell < 75%"},

--- a/tests/qcforward/test_grid_statistics.py
+++ b/tests/qcforward/test_grid_statistics.py
@@ -7,11 +7,11 @@ from fmu.tools import qcforward as qcf
 
 
 @pytest.fixture
-def make_data(tmp_path):
+def make_data(tmp_path, testdata_path):
     report_path = str(tmp_path / "somefile.csv")
     yaml_path = str(tmp_path / "somefile.yml")
     data = {
-        "path": abspath("../xtgeo-testdata/3dgrids/reek/"),
+        "path": abspath(testdata_path / "3dgrids/reek/"),
         "grid": "reek_sim_grid.roff",
         "report": report_path,
         "verbosity": 1,

--- a/tests/qcforward/test_gridquality.py
+++ b/tests/qcforward/test_gridquality.py
@@ -7,35 +7,37 @@ import pytest
 
 import fmu.tools.qcforward as qcf
 
-# filedata
 PATH = pathlib.Path(".").resolve().as_posix()
-GRIDFILE = "../xtgeo-testdata/3dgrids/reek/reek_sim_grid.roff"
 REPORT = "/tmp/somefile_gridquality.csv"
 SOMEYAML = "/tmp/somefile.yml"
 
-ACTIONS = {
-    "minangle_topbase": [
-        {"warn": "allcells > 1% when < 80", "stop": "allcells > 1% when < 50"},
-        {"warn": "allcells > 50% when < 85", "stop": "allcells > 10% when < 50"},
-    ],
-    "collapsed": [{"warn": "allcells > 20%", "stop": "allcells > 50%"}],
-}
+
+@pytest.fixture()
+def gridfile_data(testdata_path):
+    gridfile = str(testdata_path / "3dgrids/reek/reek_sim_grid.roff")
+
+    ACTIONS = {
+        "minangle_topbase": [
+            {"warn": "allcells > 1% when < 80", "stop": "allcells > 1% when < 50"},
+            {"warn": "allcells > 50% when < 85", "stop": "allcells > 10% when < 50"},
+        ],
+        "collapsed": [{"warn": "allcells > 20%", "stop": "allcells > 50%"}],
+    }
+
+    return {
+        "nametag": "MYDATA1",
+        "verbosity": "info",
+        "path": PATH,
+        "grid": gridfile,
+        "actions": ACTIONS,
+        "report": {"file": REPORT, "mode": "write"},
+        "dump_yaml": SOMEYAML,
+    }
 
 
-DATA1 = {
-    "nametag": "MYDATA1",
-    "verbosity": "info",
-    "path": PATH,
-    "grid": GRIDFILE,
-    "actions": ACTIONS,
-    "report": {"file": REPORT, "mode": "write"},
-    "dump_yaml": SOMEYAML,
-}
-
-
-def test_gridquality_asfiles():
+def test_gridquality_asfiles(gridfile_data):
     """Testing grid quality using files."""
-    qcf.grid_quality(DATA1)
+    qcf.grid_quality(gridfile_data)
 
     dfr = pd.read_csv(REPORT)
     assert dfr.loc[0, "WARN%"] == pytest.approx(2.715, 0.01)
@@ -44,12 +46,12 @@ def test_gridquality_asfiles():
     pathlib.Path(SOMEYAML).unlink()
 
 
-def test_gridquality_asfiles_shall_stop():
+def test_gridquality_asfiles_shall_stop(gridfile_data):
     """Testing gridquality using files which should trigger a stop.
 
     Here. also abbrevation "all" should here work as "allcells".
     """
-    newdata = DATA1.copy()
+    newdata = gridfile_data.copy()
     newdata["actions"] = {"faulted": [{"warn": "all > 20%", "stop": "all > 3%"}]}
 
     with pytest.raises(SystemExit):

--- a/tests/qcforward/test_qcforward_in_roxenv.py
+++ b/tests/qcforward/test_qcforward_in_roxenv.py
@@ -28,41 +28,38 @@ with contextlib.suppress(ImportError):
 TMPD = Path("TMP")
 TMPD.mkdir(parents=True, exist_ok=True)
 
-TPATH = Path("../xtgeo-testdata")
 PROJNAME = "tmp_project.rmsxxx"
-
 PRJ = str(TMPD / PROJNAME)
 
-CUBEDATA1 = TPATH / "cubes/reek/syntseis_20000101_seismic_depth_stack.segy"
 CUBENAME1 = "synth1"
-
-SURFTOPS1 = [
-    TPATH / "surfaces/reek/1/topreek_rota.gri",
-    TPATH / "surfaces/reek/1/midreek_rota.gri",
-    TPATH / "surfaces/reek/1/lowreek_rota.gri",
-]
-
 SURFCAT1 = "DS_whatever"
 SURFNAMES1 = ["TopReek", "MidReek", "BaseReek"]
-
-GRIDDATA1 = TPATH / "3dgrids/reek/reek_sim_grid.roff"
-PORODATA1 = TPATH / "3dgrids/reek/reek_sim_poro.roff"
-ZONEDATA1 = TPATH / "3dgrids/reek/reek_sim_zone.roff"
 GRIDNAME1 = "Simgrid"
 PORONAME1 = "PORO"
 ZONENAME1 = "Zone"
 
-WELLSFOLDER1 = TPATH / "wells/reek/1"
 WELLS1 = ["OP1_perf.w", "OP_2.w", "OP_6.w", "XP_with_repeat.w"]
 
 
 @pytest.mark.skipunlessroxar
 @pytest.fixture(name="create_project", scope="module", autouse=True)
-def fixture_create_project():
+def fixture_create_project(testdata_path):
     """Create a tmp RMS project for testing, populate with basic data.
 
     After the yield command, the teardown phase will remove the tmp RMS project.
     """
+
+    cubedata = testdata_path / "cubes/reek/syntseis_20000101_seismic_depth_stack.segy"
+    surftops1 = [
+        testdata_path / "surfaces/reek/1/topreek_rota.gri",
+        testdata_path / "surfaces/reek/1/midreek_rota.gri",
+        testdata_path / "surfaces/reek/1/lowreek_rota.gri",
+    ]
+    griddata1 = testdata_path / "3dgrids/reek/reek_sim_grid.roff"
+    porodata1 = testdata_path / "3dgrids/reek/reek_sim_poro.roff"
+    zonedata1 = testdata_path / "3dgrids/reek/reek_sim_zone.roff"
+    wellsfolder1 = testdata_path / "wells/reek/1"
+
     prj1 = str(PRJ)
 
     print("\n******** Setup RMS project!\n")
@@ -78,29 +75,29 @@ def fixture_create_project():
     assert "1." in rox.roxversion
 
     for wfile in WELLS1:
-        wobj = xtgeo.well_from_file(WELLSFOLDER1 / wfile)
+        wobj = xtgeo.well_from_file(wellsfolder1 / wfile)
         if "XP_with" in wfile:
             wobj.name = "OP2_w_repeat"
 
         wobj.to_roxar(project, wobj.name, logrun="log", trajectory="My trajectory")
 
     # populate with cube data
-    cube = xtgeo.cube_from_file(CUBEDATA1)
+    cube = xtgeo.cube_from_file(cubedata)
     cube.to_roxar(project, CUBENAME1, domain="depth")
 
     # populate with surface data
     rox.create_horizons_category(SURFCAT1)
     for num, name in enumerate(SURFNAMES1):
-        srf = xtgeo.surface_from_file(SURFTOPS1[num])
+        srf = xtgeo.surface_from_file(surftops1[num])
         project.horizons.create(name, roxar.HorizonType.interpreted)
         srf.to_roxar(project, name, SURFCAT1)
 
     # populate with grid and props
-    grd = xtgeo.grid_from_file(GRIDDATA1)
+    grd = xtgeo.grid_from_file(griddata1)
     grd.to_roxar(project, GRIDNAME1)
-    por = xtgeo.gridproperty_from_file(PORODATA1, name=PORONAME1)
+    por = xtgeo.gridproperty_from_file(porodata1, name=PORONAME1)
     por.to_roxar(project, GRIDNAME1, PORONAME1)
-    zon = xtgeo.gridproperty_from_file(ZONEDATA1, name=ZONENAME1)
+    zon = xtgeo.gridproperty_from_file(zonedata1, name=ZONENAME1)
     zon.values = zon.values.astype(np.uint8)
     zon.to_roxar(project, GRIDNAME1, ZONENAME1)
 

--- a/tests/qcforward/test_wellzonation_vs_grid.py
+++ b/tests/qcforward/test_wellzonation_vs_grid.py
@@ -11,25 +11,24 @@ ZONENAME = "Zone"
 ZONELOGNAME = "Zonelog"
 PERFLOGNAME = "PERF"
 
-GRIDFILE = abspath("../xtgeo-testdata/3dgrids/reek/reek_sim_grid.roff")
-ZONEFILE = abspath("../xtgeo-testdata/3dgrids/reek/reek_sim_zone.roff")
-WELLFILES = [
-    abspath("../xtgeo-testdata/wells/reek/1/OP*.w"),
-    abspath("../xtgeo-testdata/wells/reek/1/WI*.w"),
-]
-
 
 @pytest.fixture
-def make_data(tmp_path):
+def make_data(tmp_path, testdata_path):
     report_path = str(tmp_path / "somefile.csv")
     yaml_path = str(tmp_path / "somefile.yml")
+    gridfile = abspath(testdata_path / "3dgrids/reek/reek_sim_grid.roff")
+    zonefile = abspath(testdata_path / "3dgrids/reek/reek_sim_zone.roff")
+    wellfiles = [
+        abspath(testdata_path / "wells/reek/1/OP*.w"),
+        abspath(testdata_path / "wells/reek/1/WI*.w"),
+    ]
     data = {
         "nametag": "MYDATA1",
         "verbosity": "debug",
         "path": str(tmp_path),
-        "grid": GRIDFILE,
-        "gridprops": [[ZONENAME, ZONEFILE]],
-        "wells": WELLFILES,
+        "grid": gridfile,
+        "gridprops": [[ZONENAME, zonefile]],
+        "wells": wellfiles,
         "zonelog": {"name": ZONELOGNAME, "range": [1, 3]},
         "depthrange": [1580, 9999],
         "actions": [

--- a/tests/qcproperties/conftest.py
+++ b/tests/qcproperties/conftest.py
@@ -4,9 +4,9 @@ import pytest
 
 
 @pytest.fixture()
-def data_grid():
+def data_grid(testdata_path):
     return {
-        "path": abspath("../xtgeo-testdata/3dgrids/reek/"),
+        "path": abspath(testdata_path / "3dgrids/reek/"),
         "grid": "reek_sim_grid.roff",
         "properties": {
             "PORO": {"name": "reek_sim_poro.roff"},
@@ -21,9 +21,9 @@ def data_grid():
 
 
 @pytest.fixture()
-def data_wells():
+def data_wells(testdata_path):
     return {
-        "path": abspath("../xtgeo-testdata/wells/reek/1/"),
+        "path": abspath(testdata_path / "wells/reek/1/"),
         "wells": ["OP_*.w"],
         "properties": {
             "PORO": {"name": "Poro"},
@@ -38,9 +38,9 @@ def data_wells():
 
 
 @pytest.fixture()
-def data_bwells():
+def data_bwells(testdata_path):
     return {
-        "path": abspath("../xtgeo-testdata/wells/reek/1/"),
+        "path": abspath(testdata_path / "wells/reek/1/"),
         "wells": ["OP_1.bw"],
         "properties": {
             "PORO": {"name": "Poro"},

--- a/tests/rms/test_qcreset_in_roxenv.py
+++ b/tests/rms/test_qcreset_in_roxenv.py
@@ -27,41 +27,41 @@ with contextlib.suppress(ImportError):
 TMPD = Path("TMP")
 TMPD.mkdir(parents=True, exist_ok=True)
 
-TPATH = Path("../xtgeo-testdata")
 PROJNAME = "tmp_project_qcreset.rmsxxx"
-
 PRJ = str(TMPD / PROJNAME)
 
-CUBEDATA1 = TPATH / "cubes/reek/syntseis_20000101_seismic_depth_stack.segy"
 CUBENAME1 = "synth1"
-
-SURFTOPS1 = [
-    TPATH / "surfaces/reek/1/topreek_rota.gri",
-    TPATH / "surfaces/reek/1/midreek_rota.gri",
-    TPATH / "surfaces/reek/1/lowreek_rota.gri",
-]
-
 SURFCAT1 = "DS_whatever"
 SURFNAMES1 = ["TopReek", "MidReek", "BaseReek"]
-
-GRIDDATA1 = TPATH / "3dgrids/reek/reek_sim_grid.roff"
-PORODATA1 = TPATH / "3dgrids/reek/reek_sim_poro.roff"
-ZONEDATA1 = TPATH / "3dgrids/reek/reek_sim_zone.roff"
 GRIDNAME1 = "Simgrid"
 PORONAME1 = "PORO"
 ZONENAME1 = "Zone"
 
-WELLSFOLDER1 = TPATH / "wells/reek/1"
 WELLS1 = ["OP1_perf.w", "OP_2.w", "OP_6.w", "XP_with_repeat.w"]
 
 
 @pytest.mark.skipunlessroxar
 @pytest.fixture(name="create_project", scope="module", autouse=True)
-def fixture_create_project():
+def fixture_create_project(testdata_path):
     """Create a tmp RMS project for testing, populate with basic data.
 
     After the yield command, the teardown phase will remove the tmp RMS project.
     """
+
+    cubedata1 = testdata_path / "cubes/reek/syntseis_20000101_seismic_depth_stack.segy"
+
+    surftops1 = [
+        testdata_path / "surfaces/reek/1/topreek_rota.gri",
+        testdata_path / "surfaces/reek/1/midreek_rota.gri",
+        testdata_path / "surfaces/reek/1/lowreek_rota.gri",
+    ]
+
+    griddata1 = testdata_path / "3dgrids/reek/reek_sim_grid.roff"
+    porodata1 = testdata_path / "3dgrids/reek/reek_sim_poro.roff"
+    zonedata1 = testdata_path / "3dgrids/reek/reek_sim_zone.roff"
+
+    wellsfolder1 = testdata_path / "wells/reek/1"
+
     prj1 = str(PRJ)
 
     print("\n******** Setup RMS project!\n")
@@ -77,29 +77,29 @@ def fixture_create_project():
     assert "1." in rox.roxversion
 
     for wfile in WELLS1:
-        wobj = xtgeo.well_from_file(WELLSFOLDER1 / wfile)
+        wobj = xtgeo.well_from_file(wellsfolder1 / wfile)
         if "XP_with" in wfile:
             wobj.name = "OP2_w_repeat"
 
         wobj.to_roxar(project, wobj.name, logrun="log", trajectory="My trajectory")
 
     # populate with cube data
-    cube = xtgeo.cube_from_file(CUBEDATA1)
+    cube = xtgeo.cube_from_file(cubedata1)
     cube.to_roxar(project, CUBENAME1, domain="depth")
 
     # populate with surface data
     rox.create_horizons_category(SURFCAT1)
     for num, name in enumerate(SURFNAMES1):
-        srf = xtgeo.surface_from_file(SURFTOPS1[num])
+        srf = xtgeo.surface_from_file(surftops1[num])
         project.horizons.create(name, roxar.HorizonType.interpreted)
         srf.to_roxar(project, name, SURFCAT1)
 
     # populate with grid and props
-    grd = xtgeo.grid_from_file(GRIDDATA1)
+    grd = xtgeo.grid_from_file(griddata1)
     grd.to_roxar(project, GRIDNAME1)
-    por = xtgeo.gridproperty_from_file(PORODATA1, name=PORONAME1)
+    por = xtgeo.gridproperty_from_file(porodata1, name=PORONAME1)
     por.to_roxar(project, GRIDNAME1, PORONAME1)
-    zon = xtgeo.gridproperty_from_file(ZONEDATA1, name=ZONENAME1)
+    zon = xtgeo.gridproperty_from_file(zonedata1, name=ZONENAME1)
     zon.values = zon.values.astype(np.uint8)
     zon.to_roxar(project, GRIDNAME1, ZONENAME1)
 

--- a/tests/test_extract_zone_tops.py
+++ b/tests/test_extract_zone_tops.py
@@ -4,13 +4,17 @@ import pytest
 
 from fmu.tools import extract_grid_zone_tops
 
-GRID = abspath("../xtgeo-testdata/3dgrids/reek/reek_sim_grid.roff")
-GRIDPROP = abspath("../xtgeo-testdata/3dgrids/reek/reek_sim_zone.roff")
+GRID_PATH = "3dgrids/reek/reek_sim_grid.roff"
+GRIDPROP_PATH = "3dgrids/reek/reek_sim_zone.roff"
 WELLS = [abspath("tests/data/zone_tops_from_grid/OP_1.w")]
 
 
-def test_extract_no_md_log():
-    dframe = extract_grid_zone_tops(well_list=WELLS, grid=GRID, zone_param=GRIDPROP)
+def test_extract_no_md_log(testdata_path):
+    grid_path = abspath(testdata_path / GRID_PATH)
+    gridprop_path = abspath(testdata_path / GRIDPROP_PATH)
+    dframe = extract_grid_zone_tops(
+        well_list=WELLS, grid=grid_path, zone_param=gridprop_path
+    )
     assert set(dframe["ZONE"].unique()) == {
         "Below_Top_reek",
         "Below_Mid_reek",
@@ -22,9 +26,11 @@ def test_extract_no_md_log():
     assert dframe["BASE_MD"].max() == pytest.approx(2427.98, abs=0.1)
 
 
-def test_extract_with_dummy_md_log():
+def test_extract_with_dummy_md_log(testdata_path):
+    grid_path = abspath(testdata_path / GRID_PATH)
+    gridprop_path = abspath(testdata_path / GRIDPROP_PATH)
     dframe = extract_grid_zone_tops(
-        well_list=WELLS, grid=GRID, zone_param=GRIDPROP, mdlogname="MDLog"
+        well_list=WELLS, grid=grid_path, zone_param=gridprop_path, mdlogname="MDLog"
     )
     assert set(dframe["ZONE"].unique()) == {
         "Below_Top_reek",

--- a/tests/test_qcdata.py
+++ b/tests/test_qcdata.py
@@ -9,32 +9,32 @@ from fmu.tools.qcdata import QCData
 
 # filedata
 PATH = abspath(".")  # normally not needed; here due to pytest fixture tmpdir
-GRIDFILE = "../xtgeo-testdata/3dgrids/reek/reek_sim_grid.roff"
 ZONENAME = "Zone"
-ZONEFILE = "../xtgeo-testdata/3dgrids/reek/reek_sim_zone.roff"
-WELLFILES = [
-    "../xtgeo-testdata/wells/reek/1/OP*.w",
-    "../xtgeo-testdata/wells/reek/1/WI*.w",
-]
-
 ZONELOGNAME = "Zonelog"
 PERFLOGNAME = "Perflog"
 REPORT = abspath("./somefile.csv")
 
-DATA1 = {
-    "verbosity": "info",
-    "path": PATH,
-    "grid": GRIDFILE,
-    "gridprops": [[ZONENAME, ZONEFILE]],
-    "wells": WELLFILES,
-}
 
-
-def test_qcdata():
+def test_qcdata(testdata_path):
     """Testing getting data with _QCForwardData class"""
 
+    gridfile = str(testdata_path / "3dgrids/reek/reek_sim_grid.roff")
+    zonefile = str(testdata_path / "3dgrids/reek/reek_sim_zone.roff")
+    wellfiles = [
+        str(testdata_path / "wells/reek/1/OP*.w"),
+        str(testdata_path / "wells/reek/1/WI*.w"),
+    ]
+
     qcdata = QCData()
-    qcdata.parse(data=DATA1)
+    qcdata.parse(
+        data={
+            "verbosity": "info",
+            "path": PATH,
+            "grid": gridfile,
+            "gridprops": [[ZONENAME, zonefile]],
+            "wells": wellfiles,
+        }
+    )
 
     assert isinstance(qcdata, QCData)
     assert isinstance(qcdata.grid, xtgeo.Grid)


### PR DESCRIPTION
Resolves part of https://github.com/equinor/rms-sys/issues/267

Added a bash script that can be run from the github workflows to execute the `fmu-tools` unit tests towards an RMS Python Environment. The script copies the required test files, installs the test dependencies and runs the pytests. Note that the xtgeo-testdata files needed to run the tests are cached on the github actions runner som pointing to the path `XTGEO_TESTDATA_PATH` with the cached data should be sufficient to run the tests.

Tests have been updated to be able to use the testdata path `XTGEO_TESTDATA_PATH` set in the test config:
* Since the tests are to be run from a github workflow, the tests need to support xtgeo-testdata being placed at the path given by `XTGEO_TESTDATA_PATH` in the command `pytest ./tests -n 4 -vv --testdatapath $XTGEO_TESTDATA_PATH`. 

A testrun from can be seen here https://github.com/equinor/rms-sys/actions/runs/13006244695/job/36273691991
