### PR TITLE
Add check of grid zone conformity with grid building job in RMS

### DIFF
--- a/docs/copy_rms_param_to_ertbox_grid.rst
+++ b/docs/copy_rms_param_to_ertbox_grid.rst
@@ -55,6 +55,27 @@ Input is a python dictionary with all relevant specifications:
 * Optional if a active/inactive parameter is to be created in ERTBOX grid.
 * Extrapolation method when copying from geomodel grid to ERTBOX grid.
 
+Consistency check with the grid model
+--------------------------------------
+
+The keyword *Conformity* should specify the correct grid conformity for each of the zones in the grid model.
+If the grid model is built using RMS grid building job, it is possible to check that the specified conformities
+are correct. There are however a few requirements for the consistency check:
+
+* The grid model must be built by an RMS grid building job for the geogrid.
+* There can only be one RMS grid building job for the grid model that is used.
+* The option in the grid building job to *Honor* zone boundaries must be used.
+* The zone grid layout must be defined by *Horizon* as reference and not *Surface*.
+
+If all these requirements are satisfied, the keyword *Conformity* is not necessary and will
+be ignored and the grid conformity information from the grid building job will be used instead.
+In the case some of the requirements are not satisfied, the *Conformity* keyword must be specified.
+But note that in this case the grid conformity may be of a type that is not supported and this will
+have effect on the field update done by ERT.
+*It is recommended to stick to the grid conformity that is implemented.*
+If the grid is built outside of RMS or by a script, there are no check and the user will have to
+ensure this is correctly specified in the keyword *Conformity*. Some warnings will
+appear in log output when it is not possible to check conformity or the conformity is not supported.
 
 Example of RMS python job using this function to copy from geogrid to ERTBOX grid
 ----------------------------------------------------------------------------------
@@ -139,5 +160,3 @@ In this case the keywords *SaveActiveParam. AddNoiseToInactive,ExtrapolationMeth
         "ERTBoxGridName": "ERTBOX",
     }
     copy_rms_param(params)
-
-aps_fmu_tools

--- a/tests/rms/test_copy_rms_param_to_ertbox_grid.py
+++ b/tests/rms/test_copy_rms_param_to_ertbox_grid.py
@@ -18,13 +18,25 @@ import xtgeo
 
 with contextlib.suppress(ImportError):
     import rmsapi
+    from rmsapi.jobs import Job
 
 from fmu.tools.rms import copy_rms_param
+from fmu.tools.rms.copy_rms_param_to_ertbox_grid import (
+    assign_conformity,
+    check_grid_conformity,
+)
 
 # ======================================================================================
 # settings to create RMS project!
 
-DEBUG_LEVEL = 2
+
+DEBUG_OFF = 0
+DEBUG_ON = 1
+DEBUG_VERBOSE = 2
+DEBUG_VERY_VERBOSE = 3
+
+DEBUG_LEVEL = DEBUG_OFF
+
 REMOVE_RMS_PROJECT_AFTER_TEST = True
 
 TMPD = Path("TMP")
@@ -43,7 +55,33 @@ PETROPARAMS = ["P1_new", "P2_new"]
 ERTBOX_PETRO_PARAMS_A = ["ZoneA_P1", "ZoneA_P2"]
 ERTBOX_PETRO_PARAMS_B = ["ZoneB_P1", "ZoneB_P2"]
 ZONE_PARAM_NAME = "Zone"
+NX = 50
+NY = 70
+NZ_ZONEA = 10
+NZ_ZONEB = 15
+XINC = 50.0
+YINC = 50.0
+ZINC = 5.0
+ORIGIN = (0.0, 0.0, 0.0)
+ROTATION = 50.0
+ZONEA = "ZoneA"
+ZONEB = "ZoneB"
+PROPORTIONAL_CODE = 0
+TOPCONFORM_CODE = 1
+BASECONFORM_CODE = 2
+PROPORTIONAL = "Proportional"
+TOPCONFORM = "TopConform"
+BASECONFORM = "BaseConform"
 
+ZONEA = "ZoneA"
+ZONEB = "ZoneB"
+ZONEC = "ZoneC"
+ZONEA_NUMBER = 1
+ZONEB_NUMBER = 2
+ZONEC_NUMBER = 3
+
+GRID_MODEL_NAME = "Geogrid"
+GRID_BUILDING_JOB_NAME = "Grid_building_job_name"
 GEO_TO_ERTBOX_DICT = {
     "project": None,
     "debug_level": DEBUG_LEVEL,
@@ -57,8 +95,8 @@ GEO_TO_ERTBOX_DICT = {
         2: ERTBOX_PETRO_PARAMS_B,
     },
     "Conformity": {
-        1: "BaseConform",
-        2: "TopConform",
+        1: BASECONFORM,
+        2: TOPCONFORM,
     },
     "GridModelName": GRID_MODEL,
     "ZoneParam": ZONE_PARAM_NAME,
@@ -81,8 +119,8 @@ ERTBOX_TO_GEO_DICT = {
         2: ERTBOX_PETRO_PARAMS_B,
     },
     "Conformity": {
-        1: "BaseConform",
-        2: "TopConform",
+        1: BASECONFORM,
+        2: TOPCONFORM,
     },
     "GridModelName": GRID_MODEL,
     "ZoneParam": ZONE_PARAM_NAME,
@@ -90,21 +128,215 @@ ERTBOX_TO_GEO_DICT = {
 }
 
 
+class GridJob:
+    def __init__(
+        self,
+        zone_numbers: list[int],
+        zone_names: list[str],
+        conform_mode_list: list[int],
+        use_bottom_surface_list: list[bool],
+        use_top_surface_list: list[bool],
+        use_sampled_horizons_list: list[bool],
+    ) -> None:
+        self.conformal_mode_list = conform_mode_list
+        self.zone_names = zone_names
+        self.zone_numbers = zone_numbers
+        self.use_bottom_surface_list = use_bottom_surface_list
+        self.use_top_surface_list = use_top_surface_list
+        self.use_sampled_horizons_list = use_sampled_horizons_list
+
+    def get_arguments(self) -> dict:
+        return {
+            "ConformalMode": self.conformal_mode_list,
+            "ZoneNames": self.zone_names,
+            "UseBottomSurface": self.use_bottom_surface_list,
+            "UseTopSurface": self.use_top_surface_list,
+            "SampledHorizons": self.use_sampled_horizons_list,
+        }
+
+
+@pytest.mark.skipunlessroxar
+@pytest.mark.parametrize(
+    "rms_grid_building_jobs, rms_zone_numbers, rms_zone_names,"
+    "rms_conform_mode_list, rms_use_top_surface_list,"
+    "rms_use_bottom_surface_list, rms_use_sampled_horizons_list,"
+    "specified_grid_layout_list,specified_zone_numbers, debug_level",
+    [
+        # The variables starting with rms is variables read from grid buidling job
+        # The variables starting with specified is related to
+        # user specified conformities
+        (
+            # Here the conformity from the grid job is one of the implemented types
+            # and can be used. No need for usr specified conformities in this case.
+            ["Grid_building_job_1"],
+            [ZONEA_NUMBER, ZONEB_NUMBER, ZONEC_NUMBER],
+            [ZONEA, ZONEB, ZONEC],
+            [BASECONFORM_CODE, TOPCONFORM_CODE, PROPORTIONAL_CODE],
+            [False, False, False],  # Surface option not used for Top
+            [False, False, False],  # Surface option not use for Base
+            [False, False, False],  # Use 'Honor' for all horizons
+            [BASECONFORM, TOPCONFORM, PROPORTIONAL],
+            [ZONEA_NUMBER, ZONEB_NUMBER, ZONEC_NUMBER],
+            DEBUG_VERY_VERBOSE,
+        ),
+        (
+            # Here the option 'Sample' is used for zone borders.
+            # This means the grid conformity is not implemented and the
+            # user must specify conformities in this case.
+            ["Grid_building_job_2"],
+            [ZONEA_NUMBER, ZONEB_NUMBER, ZONEC_NUMBER],
+            [ZONEA, ZONEB, ZONEC],
+            [BASECONFORM_CODE, TOPCONFORM_CODE, PROPORTIONAL_CODE],
+            [False, False, False],  # Surface option not used for Top
+            [False, False, False],  # Surface option not use for Base
+            [
+                False,
+                True,
+            ],  # Use 'Honor' for first zone boundary and 'Sample' for the next
+            [BASECONFORM, TOPCONFORM, PROPORTIONAL],
+            [ZONEA_NUMBER, ZONEB_NUMBER, ZONEC_NUMBER],
+            DEBUG_VERY_VERBOSE,
+        ),
+        (
+            # Here the conformity defined in grid job uses 'Surface'
+            # option for two zones and therefore no conformity
+            # is implemented for this case for zone 1 and 3
+            # Will need a user specification of conformity for this.
+            ["Grid_building_job_3"],
+            [ZONEA_NUMBER, ZONEB_NUMBER],
+            [ZONEA, ZONEB],
+            [TOPCONFORM_CODE, TOPCONFORM_CODE],
+            [
+                True,
+                False,
+                False,
+            ],  # Surface option used for top zone 1, not for zone 2,3
+            [
+                False,
+                False,
+                True,
+            ],  # Surface option used for base zone 3, not for zone 1,2
+            [False, False, False],  # Use 'Honor' for all horizons
+            [TOPCONFORM, TOPCONFORM],
+            [ZONEA_NUMBER, ZONEB_NUMBER],
+            DEBUG_VERY_VERBOSE,
+        ),
+        (
+            # No grid building job exist. Must have user specified conformities
+            [],
+            [ZONEA_NUMBER, ZONEB_NUMBER, ZONEC_NUMBER],
+            [ZONEA, ZONEB, ZONEC],
+            [BASECONFORM_CODE, TOPCONFORM_CODE, PROPORTIONAL_CODE],
+            [False, False, False],  # Surface option not used for Top
+            [False, False, False],  # Surface option not use for Base
+            [False, False, False],  # Use 'Honor' for all horizons
+            [BASECONFORM, TOPCONFORM, PROPORTIONAL],
+            [ZONEA_NUMBER, ZONEB_NUMBER, ZONEC_NUMBER],
+            DEBUG_VERY_VERBOSE,
+        ),
+        (
+            # Multiple grid building jobs. No unique job.
+            # Must have user specified conformities
+            ["Grid_building_job1", "Grid_building_job2"],
+            [ZONEA_NUMBER, ZONEB_NUMBER, ZONEC_NUMBER],
+            [ZONEA, ZONEB, ZONEC],
+            [BASECONFORM_CODE, TOPCONFORM_CODE, PROPORTIONAL_CODE],
+            [False, False, False],  # Surface option not used for Top
+            [False, False, False],  # Surface option not used for Base
+            [False, False, False],  # Use 'Honor' for all horizons
+            [BASECONFORM, TOPCONFORM, PROPORTIONAL],
+            [ZONEA_NUMBER, ZONEB_NUMBER, ZONEC_NUMBER],
+            DEBUG_VERY_VERBOSE,
+        ),
+    ],
+)
+def test_check_grid_layout(
+    mocker,
+    rms_grid_building_jobs: list[str],
+    rms_zone_numbers: list[int],
+    rms_zone_names: list[str],
+    rms_conform_mode_list: list[int],
+    rms_use_top_surface_list: list[bool],
+    rms_use_bottom_surface_list: list[bool],
+    rms_use_sampled_horizons_list: list[bool],
+    specified_grid_layout_list: list[str],
+    specified_zone_numbers: list[int],
+    debug_level: int,
+) -> None:
+    # Create a mock version of rmsapi functions in rmsapi.jobs.Job object
+    mocker.patch.object(Job, "get_job_names", return_value=rms_grid_building_jobs)
+    mocker.patch.object(
+        Job,
+        "get_job",
+        return_value=GridJob(
+            rms_zone_numbers,
+            rms_zone_names,
+            rms_conform_mode_list,
+            rms_use_bottom_surface_list,
+            rms_use_top_surface_list,
+            rms_use_sampled_horizons_list,
+        ),
+    )
+
+    # For each zone check grid layout with RMS grid building job
+    # (here the mock of the rmsapi functions)
+
+    geogrid_param_dict = {}
+    for zone_number in specified_zone_numbers:
+        geogrid_param_dict[zone_number] = "petrovar"
+
+    params = {
+        "GridModelName": GRID_MODEL_NAME,
+        "Conformity_required": False,
+        "GeoGridParameters": geogrid_param_dict,
+    }
+
+    if not check_grid_conformity(
+        GRID_MODEL_NAME, specified_zone_numbers, debug_level=debug_level
+    ):
+        # Grid conformity is not possible to get directly from the grid
+        # Assign a user specified conformity to each zone
+        if debug_level >= DEBUG_ON:
+            print(
+                "\nCannot get grid conformity from the grid job: "
+                f"{rms_grid_building_jobs}, must rely on user specified conformity"
+            )
+        conformity_dict = {}
+        for indx, zone_number in enumerate(specified_zone_numbers):
+            conformity_dict[zone_number] = specified_grid_layout_list[indx]
+
+        params["Conformity_required"] = True
+        params["Conformity"] = conformity_dict
+    else:
+        if debug_level >= DEBUG_ON:
+            print(
+                f"\nCan get grid conformity from the grid job: {rms_grid_building_jobs}"
+            )
+
+    conformity_dict = assign_conformity(params, debug_level=DEBUG_OFF)
+    if conformity_dict:
+        for indx, zone_number in enumerate(specified_zone_numbers):
+            grid_layout = specified_grid_layout_list[indx]
+            conformity = conformity_dict[zone_number]
+            if conformity != "Undefined":
+                assert conformity == grid_layout
+
+
 def create_grids(project):
-    nx = 50
-    ny = 70
-    nz_zoneA = 10
-    nz_zoneB = 15
+    nx = NX
+    ny = NY
+    nz_zoneA = NZ_ZONEA
+    nz_zoneB = NZ_ZONEB
     nz = nz_zoneA + nz_zoneB
     dimension = (nx, ny, nz)
     dimension_ertbox = (nx, ny, max(nz_zoneA, nz_zoneB))
-    increment = (50.0, 50.0, 5.0)
-    origin = (0.0, 0.0, 0.0)
-    rotation = 45.0
+    increment = (XINC, YINC, ZINC)
+    origin = ORIGIN
+    rotation = ROTATION
 
     subgrid_dict = {
-        "ZoneA": nz_zoneA,
-        "ZoneB": nz_zoneB,
+        ZONEA: nz_zoneA,
+        ZONEB: nz_zoneB,
     }
     geogrid = xtgeo.create_box_grid(
         dimension,

--- a/tests/rms/test_copy_rms_param_to_ertbox_grid.py
+++ b/tests/rms/test_copy_rms_param_to_ertbox_grid.py
@@ -11,6 +11,7 @@ import contextlib
 import shutil
 from os.path import isdir
 from pathlib import Path
+from typing import Any
 
 import numpy as np
 import pytest
@@ -35,7 +36,7 @@ DEBUG_ON = 1
 DEBUG_VERBOSE = 2
 DEBUG_VERY_VERBOSE = 3
 
-DEBUG_LEVEL = DEBUG_OFF
+DEBUG_LEVEL = DEBUG_ON
 
 REMOVE_RMS_PROJECT_AFTER_TEST = True
 
@@ -177,7 +178,7 @@ class GridJob:
             [False, False, False],  # Use 'Honor' for all horizons
             [BASECONFORM, TOPCONFORM, PROPORTIONAL],
             [ZONEA_NUMBER, ZONEB_NUMBER, ZONEC_NUMBER],
-            DEBUG_VERY_VERBOSE,
+            DEBUG_ON,
         ),
         (
             # Here the option 'Sample' is used for zone borders.
@@ -195,7 +196,7 @@ class GridJob:
             ],  # Use 'Honor' for first zone boundary and 'Sample' for the next
             [BASECONFORM, TOPCONFORM, PROPORTIONAL],
             [ZONEA_NUMBER, ZONEB_NUMBER, ZONEC_NUMBER],
-            DEBUG_VERY_VERBOSE,
+            DEBUG_ON,
         ),
         (
             # Here the conformity defined in grid job uses 'Surface'
@@ -219,7 +220,7 @@ class GridJob:
             [False, False, False],  # Use 'Honor' for all horizons
             [TOPCONFORM, TOPCONFORM],
             [ZONEA_NUMBER, ZONEB_NUMBER],
-            DEBUG_VERY_VERBOSE,
+            DEBUG_ON,
         ),
         (
             # No grid building job exist. Must have user specified conformities
@@ -232,7 +233,7 @@ class GridJob:
             [False, False, False],  # Use 'Honor' for all horizons
             [BASECONFORM, TOPCONFORM, PROPORTIONAL],
             [ZONEA_NUMBER, ZONEB_NUMBER, ZONEC_NUMBER],
-            DEBUG_VERY_VERBOSE,
+            DEBUG_ON,
         ),
         (
             # Multiple grid building jobs. No unique job.
@@ -246,12 +247,12 @@ class GridJob:
             [False, False, False],  # Use 'Honor' for all horizons
             [BASECONFORM, TOPCONFORM, PROPORTIONAL],
             [ZONEA_NUMBER, ZONEB_NUMBER, ZONEC_NUMBER],
-            DEBUG_VERY_VERBOSE,
+            DEBUG_ON,
         ),
     ],
 )
 def test_check_grid_layout(
-    mocker,
+    mocker: Any,
     rms_grid_building_jobs: list[str],
     rms_zone_numbers: list[int],
     rms_zone_names: list[str],
@@ -322,7 +323,7 @@ def test_check_grid_layout(
                 assert conformity == grid_layout
 
 
-def create_grids(project):
+def create_grids(project: Any):
     nx = NX
     ny = NY
     nz_zoneA = NZ_ZONEA
@@ -370,7 +371,7 @@ def create_grids(project):
     ertboxgrid.to_roxar(project, GRID_MODEL_ERTBOX)
 
 
-def compare_results_with_reference(project):
+def compare_results_with_reference(project: Any):
     # Compare with reference
     for i in range(len(PETROPARAMS_REFERENCE)):
         petro_name_reference = PETROPARAMS_REFERENCE[i]
@@ -384,7 +385,7 @@ def compare_results_with_reference(project):
         assert np.allclose(values1, values2)
 
 
-def import_petro_params(project):
+def import_petro_params(project: Any):
     for i in range(len(PETROPARAMS_REFERENCE)):
         petro_name_reference = PETROPARAMS_REFERENCE[i]
         filename = Path(REFERENCE_DIR) / Path(petro_name_reference + ".roff")


### PR DESCRIPTION
The function to copy from geogrid to ERTBOX grid uses grid conformity information to copy the layers correctly. The conformity for each zone is defined by the grid building job, but this has not been used to check that the user specify correct conformity in the input to the function copy_rms_param implemented by copy_rms_param_to_ertbox_grid.py. Current PR will check the conformity with the grid when the grid building job is available in the RMS project.