### PR TITLE
BLD: Pin Sphinx < 8.2.0 until issue resolved

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ tests = [
 docs = [
     "autoapi",
     "myst-parser",
-    "sphinx",
+    "sphinx<8.2.0",
     "sphinx-argparse",
     "sphinx-autodoc-typehints<2.4",
     "sphinx-rtd-theme",


### PR DESCRIPTION
Version 8.2.0 of Sphinx breaks the build of docs. 

Sphinx has been pinned to `< 8.2.0` until issues are solved.

For context see https://github.com/equinor/atlas/issues/118