### PR TITLE
DEP: Deprecate Python 3.9, 3.10

### DIFF
--- a/.github/workflows/fmu-tools.yml
+++ b/.github/workflows/fmu-tools.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13"]
 
     permissions:
       contents: write  # For docs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ write_to = "src/fmu/tools/version.py"
 name = "fmu-tools"
 description = "Library for various tools and scripts within Fast Model Update"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.11"
 license = { file = "LICENSE" }
 authors = [
     { name = "Equinor", email = "fg_fmu-atlas@equinor.com" },
@@ -26,10 +26,9 @@ classifiers = [
     "Topic :: Software Development :: Libraries",
     "Topic :: Utilities",
     "Operating System :: POSIX :: Linux",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Natural Language :: English",
     "License :: OSI Approved :: GNU Lesser General Public License v3 (LGPLv3)",
 ]


### PR DESCRIPTION
Resolves #298 

Also 3.10, as we do not use it. Adds Python 3.13.
