### PR TITLE
Removed use of now undefined parameter in call to blocked well function to_roxar 

### DIFF
--- a/src/fmu/tools/rms/generate_bw_per_facies.py
+++ b/src/fmu/tools/rms/generate_bw_per_facies.py
@@ -92,7 +92,6 @@ def create_bw_per_facies(
             bw_name,
             well.name,
             lognames=new_log_names,
-            update_option="overwrite",
         )
 
     print("New logs: ")


### PR DESCRIPTION
Probably some changes in xtgeo where 'update_option' no longer is used together with xtgeo  blocked well function to_roxar requires a small fix in file `generate_bw_per_facies.py` 