### PR TITLE
TYP: Fix type issue in mypy with masked values

### DIFF
--- a/src/fmu/tools/rms/copy_rms_param_to_ertbox_grid.py
+++ b/src/fmu/tools/rms/copy_rms_param_to_ertbox_grid.py
@@ -824,10 +824,10 @@ def assign_undefined_vertical(
                 if method in ["extend", "extend_layer_mean"]:
                     column_values_masked[undefined_k_indices_top] = top_value
                     column_values_masked[undefined_k_indices_bottom] = bottom_value
-                    column_values_masked = fill_remaining_masked_values_within_colum(
+                    column_values_unmasked = fill_remaining_masked_values_within_colum(
                         column_values_masked, nz_ertbox
                     )
-                    ertbox_values_3d_masked[i, j, :] = column_values_masked
+                    ertbox_values_3d_masked[i, j, :] = column_values_unmasked
 
                 elif method in ["repeat", "repeat_layer_mean"]:
                     if len(undefined_k_indices_top) > 0:
@@ -881,10 +881,10 @@ def assign_undefined_vertical(
                             reverse_values_for_undefined
                         )
 
-                    column_values_masked = fill_remaining_masked_values_within_colum(
+                    column_values_unmasked = fill_remaining_masked_values_within_colum(
                         column_values_masked, nz_ertbox
                     )
-                    ertbox_values_3d_masked[i, j, :] = column_values_masked
+                    ertbox_values_3d_masked[i, j, :] = column_values_unmasked
 
     return ertbox_values_3d_masked.filled(fill_value)
 


### PR DESCRIPTION
Resolves #319 

Fix type issue with masked values: Assign return value of method ´fill_remaining_masked_values_within_colum()´ to a new variable instead of using already assigned variable with different type.

This was probably caused by NumPy releasing a new version `2.4.0` on 20.12.2025 when the type check started failing.