### PR TITLE
MAINT: Ensure proplist is not none

### DIFF
--- a/tests/test_ensembles/test_ensemble_well_props.py
+++ b/tests/test_ensembles/test_ensemble_well_props.py
@@ -176,6 +176,7 @@ def test_config_data(configdata: dict[str, dict[str, Any]]) -> None:
     cfg = ensemble_well_props.ConfigData(configdata)
     assert cfg.wellfile == str(WELLNAME2)
 
+    assert cfg.proplist is not None
     assert cfg.proplist[0].name == "Facies"
 
 
@@ -202,6 +203,9 @@ def test_compute_some_props(configdata: dict[str, dict[str, Any]]) -> None:
     wcase.well.make_ijk_from_grid(grd)
 
     myprops = [FACIESFILE1, POROFILE1]
+
+    assert cfg.proplist is not None
+
     for ncount, pcase in enumerate(myprops):
         prop = xtgeo.gridproperty_from_file(pcase)
         prop.geometry = grd


### PR DESCRIPTION
Resolves #417 

Ensures that `cfg.proplist `is not None before indexing. 

## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
