### PR TITLE
MAINT: Fix dict item entry

### DIFF
--- a/tests/qcproperties/conftest.py
+++ b/tests/qcproperties/conftest.py
@@ -5,7 +5,7 @@ import pytest
 
 
 @pytest.fixture()
-def data_grid(testdata_path: Path) -> dict[str, str | dict[str, dict[str, str]]]:
+def data_grid(testdata_path: Path) -> dict[str, str | dict[str, dict[str, str]] | int]:
     return {
         "path": abspath(testdata_path / "3dgrids/reek/"),
         "grid": "reek_sim_grid.roff",
@@ -24,7 +24,7 @@ def data_grid(testdata_path: Path) -> dict[str, str | dict[str, dict[str, str]]]
 @pytest.fixture()
 def data_wells(
     testdata_path: Path,
-) -> dict[str, str | list[str] | dict[str, dict[str, str]]]:
+) -> dict[str, str | list[str] | dict[str, dict[str, str]] | int]:
     return {
         "path": abspath(testdata_path / "wells/reek/1/"),
         "wells": ["OP_*.w"],
@@ -43,7 +43,7 @@ def data_wells(
 @pytest.fixture()
 def data_bwells(
     testdata_path: Path,
-) -> dict[str, str | list[str] | dict[str, dict[str, str]]]:
+) -> dict[str, str | list[str] | dict[str, dict[str, str]] | int]:
     return {
         "path": abspath(testdata_path / "wells/reek/1/"),
         "wells": ["OP_1.bw"],


### PR DESCRIPTION
Resolves #419 

Fix dict item entry in tests/qcproperties/conftest.py. 

## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [ ] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
