### PR TITLE
MAINT: Fix fipnum dict item incompatibility

### DIFF
--- a/src/fmu/tools/fipmapper/fipmapper.py
+++ b/src/fmu/tools/fipmapper/fipmapper.py
@@ -19,7 +19,7 @@ class FipMapper:
         self,
         *,
         yamlfile: Optional[Union[str, Path]] = None,
-        mapdata: Optional[Dict[str, str]] = None,
+        mapdata: Optional[Dict[str, Any]] = None,
         skipstring: Optional[Union[List[str], str]] = None,
     ):
         """Represent mappings between region/zones to FIPxxx.


### PR DESCRIPTION
Resolves #421 

Updated the type hint to accept nested dictionaries with arbitrary key types (e.g., `Dict[str, Any]`) to accurately reflect the actual data structure and resolve mypy type errors. This avoids unnecessary key conversions and preserves intended functionality.

## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [ ] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
