### PR TITLE
MAINT: Fix type hints

### DIFF
--- a/tests/rms/test_copy_rms_param_to_ertbox_grid.py
+++ b/tests/rms/test_copy_rms_param_to_ertbox_grid.py
@@ -204,7 +204,7 @@ class GridJob:
         }
 
 
-class ZoneMappingMock:
+class ZoneMappingMock(ZoneMapping):
     def __init__(
         self,
         number_of_grid_zones: int,
@@ -220,9 +220,7 @@ class ZoneMappingMock:
         return self.zone_dict[zone_number]["zone_index"]
 
     def get_start_end_layer_for_zone_number(self, zone_number: int) -> tuple[int, int]:
-        return self.zone_dict[zone_number]["start"], self.zone_dict_list[zone_number][
-            "end"
-        ]
+        return self.zone_dict[zone_number]["start"], self.zone_dict[zone_number]["end"]
 
     def number_of_layers_for_zone_number(self, zone_number: int) -> int:
         return self.zone_dict[zone_number]["nlayers"]
@@ -592,7 +590,7 @@ def test_copy_between_geo_and_ertbox_grids() -> None:
 
     # Load zone and petro params from file into geogrid
     file_name_zone_param = Path(REFERENCE_DIR) / Path(ZONE_PARAM_FILE)
-    import_petro_params(project, file_name_zone_param)
+    import_petro_params(project, str(file_name_zone_param))
 
     # Test 1 with zone numbering is 1 and 2 in zone parameter
     # Copy to ertbox
@@ -608,7 +606,7 @@ def test_copy_between_geo_and_ertbox_grids() -> None:
 
     # Test 2 with zone numbering is 2 and 3 in zone parameter
     file_name_zone_param = Path(REFERENCE_DIR) / Path(ZONE_PARAM_FILE_2)
-    import_petro_params(project, file_name_zone_param)
+    import_petro_params(project, str(file_name_zone_param))
     # Copy to ertbox
     GEO_TO_ERTBOX_DICT_2["project"] = project
     copy_rms_param(GEO_TO_ERTBOX_DICT_2)


### PR DESCRIPTION
Resolves #426 

Addressed multiple mypy errors in tests/rms/test_copy_rms_param_to_ertbox_grid.py by:
- Fixing attribute access issues in ZoneMappingMock (correcting typos).
- Ensuring ZoneMappingMock instances are properly typed. 
- Converting Path objects to strings before passing to functions expecting str arguments.


## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [ ] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
