### PR TITLE
MAINT: Fix type hint

### DIFF
--- a/tests/rms/test_create_rft_ertobs.py
+++ b/tests/rms/test_create_rft_ertobs.py
@@ -447,8 +447,6 @@ def test_configparsing(tmpdir: LEGACY_PATH, caplog: LogCaptureFixture) -> None:
     """Test that the function that validates and parses the config dictionary
     gives correct error messages, and returns a dict with defaults filled in"""
 
-    with pytest.raises(TypeError):
-        check_and_parse_config()
     with pytest.raises(AssertionError):
         check_and_parse_config({})
 


### PR DESCRIPTION
Resolves #428 

Fixed `test_create_rft_ertobs`.py by replacing the duplicate no-argument `check_and_parse_config() `call with `check_and_parse_config({})`, and removing the redundant TypeError assertion that only tested Python’s argument binding rather than the config parser behavior.

## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [ ] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
