### PR TITLE
ENH: zonation and upscaling for nested hybrid grid

### DIFF
--- a/docs/nestedhybridgrid.rst
+++ b/docs/nestedhybridgrid.rst
@@ -41,6 +41,10 @@ The example here runs within RMS, but similar workflows can be created for file 
     # Load grid and region property
     grid = xtgeo.grid_from_roxar(project, "Simgrid")
     region = xtgeo.gridproperty_from_roxar(project, "Simgrid", "REGION")
+    
+    # Optionally load any other parameter you wish to preserve on grid
+    #zone = xtgeo.gridproperty_from_roxar(project, "Simgrid", "Zone")
+    #grid.append_prop(zone)
 
     # Create nested hybrid grid (e.g. refine region 2 by 2×2×1)
     merged, nnc_table = create_nested_hybrid_grid(
@@ -50,11 +54,12 @@ The example here runs within RMS, but similar workflows can be created for file 
     # store merged grid in RMS (or file)
     merged.to_roxar(project, "NestedHybrid")
 
-    merged.get_prop_by_name("NEST_ID")
-    nest_id.to_roxar(project, "NestedHybrid", nest_id.name)
+    # Optionally extract and store any necessary parameters from grid
+    region2 = merged.get_prop_by_name("REGION")
+    region2.to_roxar(project, "NestedHybrid", region2.name)
 
     # write the NNC pandas to disk; this will be applied for computing NNC's in the next script
-    nnc_table.write_csv("path_to_some_csv_file.csv", index=False)
+    nnc_table.to_csv("path_to_some_csv_file.csv", index=False)
 
 
 The next step is to do a rescaling from the original geogrid to the merged grid
@@ -64,6 +69,7 @@ Further, we need to create NNC transmissibilities and generate file for flow sim
 
 .. code-block:: python
 
+    import pandas as pd
     import xtgeo
     from fmu.tools.nestedhybridgrid import (
         nnc_to_flowsimulator_input,
@@ -74,7 +80,6 @@ Further, we need to create NNC transmissibilities and generate file for flow sim
 
     # Load grid and region property which may be stored in RMS
     nested = xtgeo.grid_from_roxar(project, GNAME)
-    region = nested.get_prop_by_name("NEST_ID")  # if needed for QC
 
     # load the NNC table
     nnc_table = pd.read_csv("path_to_some_nnc_file.csv")
@@ -88,7 +93,7 @@ Further, we need to create NNC transmissibilities and generate file for flow sim
 
     # compute transmissibilities. Note that flow simulators do this for the normal cells/faults
     # so strictly speaking, only nnc_hybrid is needed here.
-    tranx, trany, tranz, nnc_fault, nnc_hybrid, rbnd = merged.get_transmissibilities(
+    tranx, trany, tranz, nnc_fault, nnc_hybrid, rbnd = nested.get_transmissibilities(
         permx, permy, permz, ntg, nnc_table=nnc_table
     )
 
@@ -96,7 +101,7 @@ Further, we need to create NNC transmissibilities and generate file for flow sim
     nnc_to_flowsimulator_input(nnc_hybrid, "some_path/NNC_HYBRID.INC")
 
     # Or map NNCs onto grid properties for visualisation
-    tx_nnc, ty_nnc, tz_nnc = nnc_to_gridproperty(merged, nnc_hybrid)
+    tx_nnc, ty_nnc, tz_nnc = nnc_to_gridproperty(nested, nnc_hybrid)
     tx_nnc.to_roxar(project, GNAME, "TRANX_NNC_QC")  # etc
 
 Concepts
@@ -126,15 +131,6 @@ This table is passed to :meth:`xtgeo.Grid.get_transmissibilities` via the
 ``nnc_table`` parameter.  The transmissibility computation uses geometric
 face-overlap calculations (Sutherland–Hodgman algorithm) and two-point flux
 approximation (TPFA).
-
-NEST_ID property
-^^^^^^^^^^^^^^^^
-
-The merged grid carries a discrete property called ``NEST_ID``:
-
-- **0** — inactive hole cells (carved out to make room for the refined region)
-- **1** — mother (coarse) cells
-- **2** — refined cells
 
 Eclipse / OPM Flow export
 ^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/nestedhybridgrid.rst
+++ b/docs/nestedhybridgrid.rst
@@ -47,9 +47,24 @@ The example here runs within RMS, but similar workflows can be created for file 
     #grid.append_prop(zone)
 
     # Create nested hybrid grid (e.g. refine region 2 by 2×2×1)
-    merged, nnc_table = create_nested_hybrid_grid(
+    merged, nnc_table, _ = create_nested_hybrid_grid(
         grid, region, target_region_id=2, refinement=(2, 2, 1)
     )
+
+    # Optionally send upscaling mappings from geogrid to be updated
+    # uip/ujp/ukp map Geogrid to Simgrid
+    # uip2/ujp2/ukp2 map Geogrid to NestedHybrid
+
+    #uip = xtgeo.gridproperty_from_roxar(project, "Geogrid", "C_upscale")
+    #ujp = xtgeo.gridproperty_from_roxar(project, "Geogrid", "R_upscale")
+    #ukp = xtgeo.gridproperty_from_roxar(project, "Geogrid", "L_upscale")
+    #merged, nnc_table, upscale = create_nested_hybrid_grid(
+    #    grid, region, target_region_id=2, refinement=(2, 2, 1), upscaling=(uip,ujp,ukp)
+    #)
+    #uip2, ujp2, ukp2 = upscale
+    #uip2.to_roxar(project, "Geogrid", "C_upscale")
+    #ujp2.to_roxar(project, "Geogrid", "R_upscale")
+    #ukp2.to_roxar(project, "Geogrid", "L_upscale")
 
     # store merged grid in RMS (or file)
     merged.to_roxar(project, "NestedHybrid")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
     "pyyaml>=5.3",
     "scipy>=1.2",
     "xlrd>=1.2",
-    "xtgeo>=4.21.0",
+    "xtgeo>=4.23.0",
 ]
 
 [project.optional-dependencies]

--- a/src/fmu/tools/nestedhybridgrid/nestedhybrid.py
+++ b/src/fmu/tools/nestedhybridgrid/nestedhybrid.py
@@ -17,12 +17,12 @@ nnc_to_flowsimulator_input : function
 from __future__ import annotations
 
 import logging
+import warnings
 from typing import TYPE_CHECKING
 
 import numpy as np
 import pandas as pd
 import xtgeo
-import warnings
 
 if TYPE_CHECKING:
     import os
@@ -309,6 +309,7 @@ def _generate_layer_mappings(
 
     return (lmap1, lmap2)
 
+
 def _modify_upscaling_mapping(
     up: tuple[xtgeo.GridProperty, xtgeo.GridProperty, xtgeo.GridProperty],
     region: xtgeo.GridProperty,
@@ -364,89 +365,84 @@ def _modify_upscaling_mapping(
         raise ValueError("Invalid input upscaling relationships")
 
     exclude_mask = (iv == -1) | (jv == -1) | (kv == -1)
-   
+
     # map region from input grid to geogrid
-    cn = np.ma.masked_where(exclude_mask,iv * jvm * kvm + jv * kvm + kv)
+    cn = np.ma.masked_where(exclude_mask, iv * jvm * kvm + jv * kvm + kv)
     # mask any inactive cells
     cn.mask[~cn.mask] = region.values.mask.reshape(-1)[cn[~cn.mask].astype(np.int32)]
-    iv[cn.mask & (~exclude_mask)]=-1
-    jv[cn.mask & (~exclude_mask)]=-1
-    kv[cn.mask & (~exclude_mask)]=-1
+    iv[cn.mask & (~exclude_mask)] = -1
+    jv[cn.mask & (~exclude_mask)] = -1
+    kv[cn.mask & (~exclude_mask)] = -1
 
     region2 = np.ma.masked_array(np.zeros(len(cn)), mask=cn.mask)
     region2[~cn.mask] = region.values.reshape(-1)[cn[~cn.mask].astype(np.int32)]
-    
+
     # for cells that aren't refined only layer numbering updates
     kv[(~cn.mask) & (region2 != target_region_id)] = lmap[
         kv[(~cn.mask) & (region2 != target_region_id)].astype(np.int32)
     ]
 
     # for cells that are refined find the levels of refinement
-    cijk=np.argwhere(region.values == target_region_id)
-    cijk2=np.argwhere(region2.reshape(imap.values.shape) == target_region_id)
+    cijk = np.argwhere(region.values == target_region_id)
+    cijk2 = np.argwhere(region2.reshape(imap.values.shape) == target_region_id)
     cnr = cijk[:, 0] * jvm * kvm + cijk[:, 1] * kvm + cijk[:, 2]
 
     # find number of cells in refined region on geogrid and normal grid
-    ccnt = [len(np.unique(cijk[:,x])) for x in range(3)]    
-    ccnt2 = [len(np.unique(cijk2[:,x])) for x in range(3)]
+    ccnt = [len(np.unique(cijk[:, x])) for x in range(3)]
+    ccnt2 = [len(np.unique(cijk2[:, x])) for x in range(3)]
 
     if any(ccnt2[x] % ccnt[x] > 0 for x in range(3)):
-        warnings.warn("Unable to find a valid correspondence upscaling between geogrid and input grid")
+        warnings.warn(
+            "Unable to find a valid correspondence upscaling between geogrid and input"
+            " grid"
+        )
         return None
-    
+
     uri = int(ccnt2[0] / ccnt[0])
     urj = int(ccnt2[1] / ccnt[1])
     urk = int(ccnt2[2] / ccnt[2])
-    
-    # original index map of refined cells 
+
+    # original index map of refined cells
     il2 = (
-        np.repeat(
-            np.arange(int(di / ri), dtype=np.int32) + oi, ri * dj * dk
-        )
+        np.repeat(np.arange(int(di / ri), dtype=np.int32) + oi, ri * dj * dk)
     ).reshape((di, dj, dk))
     jl2 = np.swapaxes(
-        (
-            np.repeat(
-                np.arange(int(dj / rj), dtype=np.int32) + oj, rj * di * dk
-            )
-        ).reshape((dj, di, dk)),
+        (np.repeat(np.arange(int(dj / rj), dtype=np.int32) + oj, rj * di * dk)).reshape(
+            (dj, di, dk)
+        ),
         0,
         1,
     )
     kl2 = np.swapaxes(
-        (
-            np.repeat(
-                np.arange(int(dk / rk), dtype=np.int32) + ok, rk * di * dj
-            )
-        ).reshape((dk, dj, di)),
+        (np.repeat(np.arange(int(dk / rk), dtype=np.int32) + ok, rk * di * dj)).reshape(
+            (dk, dj, di)
+        ),
         0,
         2,
     )
-    # map the updated refined grid cells to geogrid 
+    # map the updated refined grid cells to geogrid
     cmap2 = np.arange(di, dtype=np.float32) + ivm + 1
     cmap2 = np.repeat(cmap2, dj * dk).reshape((di, dj, dk))
     rmap2 = np.arange(dj, dtype=np.float32)
-    rmap2 = np.swapaxes(
-        np.repeat(rmap2, di * dk).reshape((dj, di, dk)), 0, 1
-    )
+    rmap2 = np.swapaxes(np.repeat(rmap2, di * dk).reshape((dj, di, dk)), 0, 1)
     lmap2 = np.arange(dk, dtype=np.float32) + ok
     lmap2 = np.tile(lmap2, di * dj).reshape((di, dj, dk))
 
-    if uri>ri:
+    if uri > ri:
         il2 = np.repeat(il2, int(uri / ri), axis=0)
         jl2 = np.repeat(jl2, int(uri / ri), axis=0)
         kl2 = np.repeat(kl2, int(uri / ri), axis=0)
         cmap2 = np.repeat(cmap2, int(uri / ri), axis=0)
         rmap2 = np.repeat(rmap2, int(uri / ri), axis=0)
         lmap2 = np.repeat(lmap2, int(uri / ri), axis=0)
-    if urj>rj:
+    if urj > rj:
         il2 = np.repeat(il2, int(urj / rj), axis=1)
         jl2 = np.repeat(jl2, int(urj / rj), axis=1)
         kl2 = np.repeat(kl2, int(urj / rj), axis=1)
         cmap2 = np.repeat(cmap2, int(urj / rj), axis=1)
         rmap2 = np.repeat(rmap2, int(urj / rj), axis=1)
         lmap2 = np.repeat(lmap2, int(urj / rj), axis=1)
-    if urk>rk:
+    if urk > rk:
         il2 = np.repeat(il2, int(urk / rk), axis=2)
         jl2 = np.repeat(jl2, int(urk / rk), axis=2)
         kl2 = np.repeat(kl2, int(urk / rk), axis=2)
@@ -454,55 +450,50 @@ def _modify_upscaling_mapping(
         rmap2 = np.repeat(rmap2, int(urk / rk), axis=2)
         lmap2 = np.repeat(lmap2, int(urk / rk), axis=2)
 
-    il2=il2.reshape(-1)
-    jl2=jl2.reshape(-1)
-    kl2=kl2.reshape(-1)
-    cmap2=cmap2.reshape(-1)
-    rmap2=rmap2.reshape(-1)
-    lmap2=lmap2.reshape(-1)
+    il2 = il2.reshape(-1)
+    jl2 = jl2.reshape(-1)
+    kl2 = kl2.reshape(-1)
+    cmap2 = cmap2.reshape(-1)
+    rmap2 = rmap2.reshape(-1)
+    lmap2 = lmap2.reshape(-1)
 
     cl2 = il2 * jvm * kvm + jl2 * kvm + kl2
 
     # ensure only correct cells are updated
-    geomask = (region2 == target_region_id)
-    refmask = np.isin(cl2,cnr)
+    geomask = region2 == target_region_id
+    refmask = np.isin(cl2, cnr)
     iv[geomask] = cmap2[refmask]
     jv[geomask] = rmap2[refmask]
     kv[geomask] = lmap2[refmask]
-    
+
     imap.values = iv.reshape(imap.values.shape).astype(np.float32) + 1.0
     jmap.values = jv.reshape(imap.values.shape).astype(np.float32) + 1.0
     kmap.values = kv.reshape(imap.values.shape).astype(np.float32) + 1.0
 
     return (imap, jmap, kmap)
 
-def _set_zonation(
-    subgrid: dict,
-    lmap: np.ndarray,
-    nlay: int
-) -> dict:
+
+def _set_zonation(subgrid: dict, lmap: np.ndarray, nlay: int) -> dict:
     """Create an updated subgrid dictionary for the merged grid.
     Args:
         subgrid: subgrid dictionary from input grid
         lmap: layer mapping for grid1 - unrefined input grid
         nlay: total number of layers in merged grid
-    """ 
-    
-    updated_subgrid={}
-    
-    #sorted list of zones to add
-    zl=sorted(subgrid, key = lambda x: subgrid[x][0])
-    
+    """
+
+    updated_subgrid = {}
+
+    # sorted list of zones to add
+    zl = sorted(subgrid, key=lambda x: subgrid[x][0])
+
     for zi in range(len(zl)):
-      zn=zl[zi]
-      zmin=lmap[subgrid[zn][0]-1]+1
-      if zi==len(zl)-1:
-        zmax=nlay+1
-      else:
-        zmax=lmap[subgrid[zl[zi+1]][0]-1]+1
-      updated_subgrid[zn]=range(zmin,zmax)
+        zn = zl[zi]
+        zmin = lmap[subgrid[zn][0] - 1] + 1
+        zmax = nlay + 1 if zi == len(zl) - 1 else lmap[subgrid[zl[zi + 1]][0] - 1] + 1
+        updated_subgrid[zn] = range(zmin, zmax)
 
     return updated_subgrid
+
 
 # ---------------------------------------------------------------------------
 # Public API
@@ -514,7 +505,8 @@ def create_nested_hybrid_grid(
     region: xtgeo.GridProperty,
     target_region_id: int,
     refinement: tuple[int, int, int],
-    upscaling: tuple[xtgeo.GridProperty, xtgeo.GridProperty, xtgeo.GridProperty] | None = None,
+    upscaling: tuple[xtgeo.GridProperty, xtgeo.GridProperty, xtgeo.GridProperty]
+    | None = None,
 ) -> tuple[
     xtgeo.Grid,
     pd.DataFrame,
@@ -550,7 +542,7 @@ def create_nested_hybrid_grid(
         refinement: ``(ncol, nrow, nlay)`` refinement factors.
         upscaling: Optional tuple of `xtgeo.GridProperty` for (I,J,K)
             Geogrid properties. These map from geogrid cell to input grid
-            The input values must be a valid mapping for upscaling from 
+            The input values must be a valid mapping for upscaling from
             the geogrid to the input grid give. A value of 0 can be used
             to exclude the geogrid cell from upscaling
 
@@ -624,11 +616,7 @@ def create_nested_hybrid_grid(
     merged = xtgeo.grid_merge(grid, refined, lmap1, lmap2)
     _logger.info("Merged grid dimensions: %s", merged.dimensions)
     if subgrid is not None:
-        merged.subgrids=_set_zonation(
-            subgrid=subgrid,
-            lmap=lmap1,
-            nlay=merged.nlay  
-        )
+        merged.subgrids = _set_zonation(subgrid=subgrid, lmap=lmap1, nlay=merged.nlay)
 
     # 8. Update upscaling map if needed
     if upscaling is not None:

--- a/src/fmu/tools/nestedhybridgrid/nestedhybrid.py
+++ b/src/fmu/tools/nestedhybridgrid/nestedhybrid.py
@@ -367,12 +367,14 @@ def _modify_upscaling_mapping(
     exclude_mask = (iv == -1) | (jv == -1) | (kv == -1)
 
     # map region from input grid to geogrid
+    # excluding any enteries for cells in geogrid that are excluded
     cn = np.ma.masked_where(exclude_mask, iv * jvm * kvm + jv * kvm + kv)
-    # mask any inactive cells
-    cn.mask[~cn.mask] = region.values.mask.reshape(-1)[cn[~cn.mask].astype(np.int32)]
-    iv[cn.mask & (~exclude_mask)] = -1
-    jv[cn.mask & (~exclude_mask)] = -1
-    kv[cn.mask & (~exclude_mask)] = -1
+    # mask any inactive cells in the input grid that are mapped by geogrid
+    iv[~cn.mask][region.values.mask.reshape(-1)[cn[~cn.mask].astype(np.int32)]] = -1
+    jv[~cn.mask][region.values.mask.reshape(-1)[cn[~cn.mask].astype(np.int32)]] = -1
+    kv[~cn.mask][region.values.mask.reshape(-1)[cn[~cn.mask].astype(np.int32)]] = -1
+    exclude_mask = (iv == -1) | (jv == -1) | (kv == -1)
+    cn = np.ma.masked_where(exclude_mask, cn)
 
     region2 = np.ma.masked_array(np.zeros(len(cn)), mask=cn.mask)
     region2[~cn.mask] = region.values.reshape(-1)[cn[~cn.mask].astype(np.int32)]
@@ -450,21 +452,14 @@ def _modify_upscaling_mapping(
         rmap2 = np.repeat(rmap2, int(urk / rk), axis=2)
         lmap2 = np.repeat(lmap2, int(urk / rk), axis=2)
 
-    il2 = il2.reshape(-1)
-    jl2 = jl2.reshape(-1)
-    kl2 = kl2.reshape(-1)
-    cmap2 = cmap2.reshape(-1)
-    rmap2 = rmap2.reshape(-1)
-    lmap2 = lmap2.reshape(-1)
-
-    cl2 = il2 * jvm * kvm + jl2 * kvm + kl2
+    cl2 = il2.reshape(-1) * jvm * kvm + jl2.reshape(-1) * kvm + kl2.reshape(-1)
 
     # ensure only correct cells are updated
     geomask = region2 == target_region_id
     refmask = np.isin(cl2, cnr)
-    iv[geomask] = cmap2[refmask]
-    jv[geomask] = rmap2[refmask]
-    kv[geomask] = lmap2[refmask]
+    iv[geomask] = cmap2.reshape(-1)[refmask]
+    jv[geomask] = rmap2.reshape(-1)[refmask]
+    kv[geomask] = lmap2.reshape(-1)[refmask]
 
     imap.values = iv.reshape(imap.values.shape).astype(np.float32) + 1.0
     jmap.values = jv.reshape(imap.values.shape).astype(np.float32) + 1.0

--- a/src/fmu/tools/nestedhybridgrid/nestedhybrid.py
+++ b/src/fmu/tools/nestedhybridgrid/nestedhybrid.py
@@ -22,6 +22,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 import pandas as pd
 import xtgeo
+import warnings
 
 if TYPE_CHECKING:
     import os
@@ -308,6 +309,200 @@ def _generate_layer_mappings(
 
     return (lmap1, lmap2)
 
+def _modify_upscaling_mapping(
+    up: tuple[xtgeo.GridProperty, xtgeo.GridProperty, xtgeo.GridProperty],
+    region: xtgeo.GridProperty,
+    target_region_id: int,
+    refinement: tuple[int, int, int],
+    offset: tuple[int, int, int],
+    grid2_dims: tuple[int, int, int],
+    lmap: np.ndarray,
+) -> tuple[xtgeo.GridProperty, xtgeo.GridProperty, xtgeo.GridProperty] | None:
+    """Update a cell mapping for upscaling
+    Args:
+        up: (
+            I_property - xtgeo.GridProperty on geogrid mapping cells to input grid I
+            J_property - xtgeo.GridProperty on geogrid mapping cells to input grid J
+            K_property - xtgeo.GridProperty on geogrid mapping cells to input grid K
+            )
+        region: input region (before merging)
+        target_region_id: region to be refined
+        refinement: refinement (i,j,k) to be applied per cell in target region
+        offset: start cell of the refinement region
+        grid2_dims: (columns, rows, layers) in refined grid
+        lmap: layer mapping for grid1 (not refined)
+
+    Returns:
+        (
+        I_property - xtgeo.GridProperty on geogrid mapping cells to updated grid I
+        J_property - xtgeo.GridProperty on geogrid mapping cells to updated grid J
+        K_property - xtgeo.GridProperty on geogrid mapping cells to updated grid K
+        )
+
+    """
+    imap, jmap, kmap = up
+    oi, oj, ok = offset
+    ri, rj, rk = refinement
+    di, dj, dk = grid2_dims
+
+    ivm = region.ncol
+    jvm = region.nrow
+    kvm = region.nlay
+
+    iv = imap.values.copy().reshape(-1) - 1
+    jv = jmap.values.copy().reshape(-1) - 1
+    kv = kmap.values.copy().reshape(-1) - 1
+
+    if (
+        iv.min() < -1
+        or jv.min() < -1
+        or kv.min() < -1
+        or iv.max() >= region.ncol
+        or jv.max() >= region.nrow
+        or kv.max() >= region.nlay
+    ):
+        raise ValueError("Invalid input upscaling relationships")
+
+    exclude_mask = (iv == -1) | (jv == -1) | (kv == -1)
+   
+    # map region from input grid to geogrid
+    cn = np.ma.masked_where(exclude_mask,iv * jvm * kvm + jv * kvm + kv)
+    # mask any inactive cells
+    cn.mask[~cn.mask] = region.values.mask.reshape(-1)[cn[~cn.mask].astype(np.int32)]
+    iv[cn.mask & (~exclude_mask)]=-1
+    jv[cn.mask & (~exclude_mask)]=-1
+    kv[cn.mask & (~exclude_mask)]=-1
+
+    region2 = np.ma.masked_array(np.zeros(len(cn)), mask=cn.mask)
+    region2[~cn.mask] = region.values.reshape(-1)[cn[~cn.mask].astype(np.int32)]
+    
+    # for cells that aren't refined only layer numbering updates
+    kv[(~cn.mask) & (region2 != target_region_id)] = lmap[
+        kv[(~cn.mask) & (region2 != target_region_id)].astype(np.int32)
+    ]
+
+    # for cells that are refined find the levels of refinement
+    cijk=np.argwhere(region.values == target_region_id)
+    cijk2=np.argwhere(region2.reshape(imap.values.shape) == target_region_id)
+    cnr = cijk[:, 0] * jvm * kvm + cijk[:, 1] * kvm + cijk[:, 2]
+
+    # find number of cells in refined region on geogrid and normal grid
+    ccnt = [len(np.unique(cijk[:,x])) for x in range(3)]    
+    ccnt2 = [len(np.unique(cijk2[:,x])) for x in range(3)]
+
+    if any(ccnt2[x] % ccnt[x] > 0 for x in range(3)):
+        warnings.warn("Unable to find a valid correspondence upscaling between geogrid and input grid")
+        return None
+    
+    uri = int(ccnt2[0] / ccnt[0])
+    urj = int(ccnt2[1] / ccnt[1])
+    urk = int(ccnt2[2] / ccnt[2])
+    
+    # original index map of refined cells 
+    il2 = (
+        np.repeat(
+            np.arange(int(di / ri), dtype=np.int32) + oi, ri * dj * dk
+        )
+    ).reshape((di, dj, dk))
+    jl2 = np.swapaxes(
+        (
+            np.repeat(
+                np.arange(int(dj / rj), dtype=np.int32) + oj, rj * di * dk
+            )
+        ).reshape((dj, di, dk)),
+        0,
+        1,
+    )
+    kl2 = np.swapaxes(
+        (
+            np.repeat(
+                np.arange(int(dk / rk), dtype=np.int32) + ok, rk * di * dj
+            )
+        ).reshape((dk, dj, di)),
+        0,
+        2,
+    )
+    # map the updated refined grid cells to geogrid 
+    cmap2 = np.arange(di, dtype=np.float32) + ivm + 1
+    cmap2 = np.repeat(cmap2, dj * dk).reshape((di, dj, dk))
+    rmap2 = np.arange(dj, dtype=np.float32)
+    rmap2 = np.swapaxes(
+        np.repeat(rmap2, di * dk).reshape((dj, di, dk)), 0, 1
+    )
+    lmap2 = np.arange(dk, dtype=np.float32) + ok
+    lmap2 = np.tile(lmap2, di * dj).reshape((di, dj, dk))
+
+    if uri>ri:
+        il2 = np.repeat(il2, int(uri / ri), axis=0)
+        jl2 = np.repeat(jl2, int(uri / ri), axis=0)
+        kl2 = np.repeat(kl2, int(uri / ri), axis=0)
+        cmap2 = np.repeat(cmap2, int(uri / ri), axis=0)
+        rmap2 = np.repeat(rmap2, int(uri / ri), axis=0)
+        lmap2 = np.repeat(lmap2, int(uri / ri), axis=0)
+    if urj>rj:
+        il2 = np.repeat(il2, int(urj / rj), axis=1)
+        jl2 = np.repeat(jl2, int(urj / rj), axis=1)
+        kl2 = np.repeat(kl2, int(urj / rj), axis=1)
+        cmap2 = np.repeat(cmap2, int(urj / rj), axis=1)
+        rmap2 = np.repeat(rmap2, int(urj / rj), axis=1)
+        lmap2 = np.repeat(lmap2, int(urj / rj), axis=1)
+    if urk>rk:
+        il2 = np.repeat(il2, int(urk / rk), axis=2)
+        jl2 = np.repeat(jl2, int(urk / rk), axis=2)
+        kl2 = np.repeat(kl2, int(urk / rk), axis=2)
+        cmap2 = np.repeat(cmap2, int(urk / rk), axis=2)
+        rmap2 = np.repeat(rmap2, int(urk / rk), axis=2)
+        lmap2 = np.repeat(lmap2, int(urk / rk), axis=2)
+
+    il2=il2.reshape(-1)
+    jl2=jl2.reshape(-1)
+    kl2=kl2.reshape(-1)
+    cmap2=cmap2.reshape(-1)
+    rmap2=rmap2.reshape(-1)
+    lmap2=lmap2.reshape(-1)
+
+    cl2 = il2 * jvm * kvm + jl2 * kvm + kl2
+
+    # ensure only correct cells are updated
+    geomask = (region2 == target_region_id)
+    refmask = np.isin(cl2,cnr)
+    iv[geomask] = cmap2[refmask]
+    jv[geomask] = rmap2[refmask]
+    kv[geomask] = lmap2[refmask]
+    
+    imap.values = iv.reshape(imap.values.shape).astype(np.float32) + 1.0
+    jmap.values = jv.reshape(imap.values.shape).astype(np.float32) + 1.0
+    kmap.values = kv.reshape(imap.values.shape).astype(np.float32) + 1.0
+
+    return (imap, jmap, kmap)
+
+def _set_zonation(
+    subgrid: dict,
+    lmap: np.ndarray,
+    nlay: int
+) -> dict:
+    """Create an updated subgrid dictionary for the merged grid.
+    Args:
+        subgrid: subgrid dictionary from input grid
+        lmap: layer mapping for grid1 - unrefined input grid
+        nlay: total number of layers in merged grid
+    """ 
+    
+    updated_subgrid={}
+    
+    #sorted list of zones to add
+    zl=sorted(subgrid, key = lambda x: subgrid[x][0])
+    
+    for zi in range(len(zl)):
+      zn=zl[zi]
+      zmin=lmap[subgrid[zn][0]-1]+1
+      if zi==len(zl)-1:
+        zmax=nlay+1
+      else:
+        zmax=lmap[subgrid[zl[zi+1]][0]-1]+1
+      updated_subgrid[zn]=range(zmin,zmax)
+
+    return updated_subgrid
 
 # ---------------------------------------------------------------------------
 # Public API
@@ -319,9 +514,11 @@ def create_nested_hybrid_grid(
     region: xtgeo.GridProperty,
     target_region_id: int,
     refinement: tuple[int, int, int],
+    upscaling: tuple[xtgeo.GridProperty, xtgeo.GridProperty, xtgeo.GridProperty] | None = None,
 ) -> tuple[
     xtgeo.Grid,
     pd.DataFrame,
+    tuple[xtgeo.GridProperty, xtgeo.GridProperty, xtgeo.GridProperty] | None,
 ]:
     """Create a nested hybrid grid by refining one region and merging it back.
 
@@ -351,12 +548,19 @@ def create_nested_hybrid_grid(
             regions (e.g. an integer region parameter).
         target_region_id: The region value to refine.
         refinement: ``(ncol, nrow, nlay)`` refinement factors.
+        upscaling: Optional tuple of `xtgeo.GridProperty` for (I,J,K)
+            Geogrid properties. These map from geogrid cell to input grid
+            The input values must be a valid mapping for upscaling from 
+            the geogrid to the input grid give. A value of 0 can be used
+            to exclude the geogrid cell from upscaling
 
     Returns:
         A tuple ``(merged_grid, nnc_table)`` where *merged_grid*
         is a new :class:`xtgeo.Grid` with the refined region stitched back into
         the coarse grid and *nnc_table* is a :class:`pandas.DataFrame` mapping
-        mother cells to their connected refined cells.
+        mother cells to their connected refined cells. Upscaling tuple is a tuple
+        with 3 :class:`xtgeo.GridProperty` (I, J, K) with the updated mapping
+        from geogrid to merged grid for upscaling.
     """
     if any(r < 1 for r in refinement):
         raise ValueError(f"Refinement factors must be >= 1, got {refinement}")
@@ -370,6 +574,9 @@ def create_nested_hybrid_grid(
     # Make working copies so the caller's objects are not mutated.
     grid = grid.copy()
     region = region.copy()
+
+    # Save input zonation
+    subgrid = grid.subgrids
 
     # Attach the region property to the grid.
     grid.append_prop(region)
@@ -416,8 +623,28 @@ def create_nested_hybrid_grid(
     # 7. Merge the two grids.
     merged = xtgeo.grid_merge(grid, refined, lmap1, lmap2)
     _logger.info("Merged grid dimensions: %s", merged.dimensions)
+    if subgrid is not None:
+        merged.subgrids=_set_zonation(
+            subgrid=subgrid,
+            lmap=lmap1,
+            nlay=merged.nlay  
+        )
 
-    return merged, nnc_table
+    # 8. Update upscaling map if needed
+    if upscaling is not None:
+        updated_upscaling = _modify_upscaling_mapping(
+            upscaling,
+            region,
+            target_region_id,
+            refinement,
+            crop_origin,
+            (refined.dimensions.ncol, refined.dimensions.nrow, refined.dimensions.nlay),
+            lmap1,
+        )
+    else:
+        updated_upscaling = None
+
+    return merged, nnc_table, updated_upscaling
 
 
 def nnc_to_gridproperty(

--- a/src/fmu/tools/nestedhybridgrid/nestedhybrid.py
+++ b/src/fmu/tools/nestedhybridgrid/nestedhybrid.py
@@ -130,6 +130,8 @@ def _compute_nnc_table(
     crop_origin: tuple[int, int, int],
     refinement: tuple[int, int, int],
     coarse_ncol: int,
+    lmap1: np.ndarray,
+    lmap2: np.ndarray,
 ) -> pd.DataFrame:
     """Compute NNC cell-pair mapping between mother and refined cells.
 
@@ -155,6 +157,9 @@ def _compute_nnc_table(
         crop_origin: 0-based ``(i0, j0, k0)`` origin of the crop box.
         refinement: ``(rcol, rrow, rlay)`` refinement factors.
         coarse_ncol: Number of columns in the coarse grid (grid1 in the merge).
+        lmap1: Numpy array with layer_mapping (input k -> output k) for grid1
+        lmap2: Numpy array with layer_mapping (input k -> output k) for grid2
+
 
     Returns:
         A DataFrame with columns ``I1, J1, K1, I2, J2, K2, DIRECTION``.
@@ -163,6 +168,7 @@ def _compute_nnc_table(
 
     rcol, rrow, rlay = refinement
     i0, j0, k0 = crop_origin
+
     # In the merged grid, grid2 (refined) starts after a 1-column gap:
     i_offset = coarse_ncol + 1
 
@@ -234,10 +240,10 @@ def _compute_nnc_table(
                         {
                             "I1": mi + 1,
                             "J1": mj + 1,
-                            "K1": mk + 1,
+                            "K1": lmap1[mk] + 1,
                             "I2": ri + i_offset + 1,
                             "J2": rj + 1,
-                            "K2": rk + 1,
+                            "K2": lmap2[rk] + 1,
                             "DIRECTION": direction,
                         }
                     )
@@ -271,6 +277,38 @@ def _set_actnum_by_region(
     grid.set_actnum(actnum)
 
 
+def _generate_layer_mappings(
+    coarse_nlay: int,
+    refined_nlay: int,
+    refinement: tuple[int, int, int],
+    crop_origin: tuple[int, int, int],
+) -> tuple[np.ndarray, np.ndarray]:
+    """Generate mappings from old to new layer number.
+    Args:
+        coarse_nlay: Number of layers in the coarse grid (grid1 in the merge).
+        refined_nlay: Number of layers in the refined grid (grid2 in the merge).
+        crop_origin: 0-based ``(i0, j0, k0)`` origin of the crop box.
+        refinement: ``(rcol, rrow, rlay)`` refinement factors.
+
+    Returns:
+        lmap1: Numpy array with layer_mapping (input k -> output k) for grid1
+        lmap2: Numpy array with layer_mapping (input k -> output k) for grid2
+    """
+
+    _, _, rlay = refinement
+    _, _, k0 = crop_origin
+
+    lmap1 = np.arange(coarse_nlay, dtype=np.int32)
+    lmap1 = lmap1 + np.where(
+        lmap1 < k0,
+        0,
+        (rlay - 1) * np.minimum(int(refined_nlay / rlay), lmap1 - k0),
+    )
+    lmap2 = np.arange(refined_nlay, dtype=np.int32) + k0
+
+    return (lmap1, lmap2)
+
+
 # ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
@@ -281,17 +319,16 @@ def create_nested_hybrid_grid(
     region: xtgeo.GridProperty,
     target_region_id: int,
     refinement: tuple[int, int, int],
-) -> tuple[xtgeo.Grid, pd.DataFrame]:
+) -> tuple[
+    xtgeo.Grid,
+    pd.DataFrame,
+]:
     """Create a nested hybrid grid by refining one region and merging it back.
 
     The cells belonging to *target_region_id* are replaced by a refined
-    (subdivided) version of the same region.  A ``NEST_ID`` discrete property
-    is attached to the merged grid, encoding the nested hybrid structure:
+    (subdivided) version of the same region.
 
-    - ``NEST_ID == 1``: coarse (mother) grid cells.
-    - ``NEST_ID == 2``: refined grid cells.
-
-    In addition, a **NNC mapping table** is returned that lists every
+    A **NNC mapping table** is returned that lists every
     mother ↔ refined cell pair that should be connected by a Non-Neighbour
     Connection (NNC).  The table is derived from the topological knowledge
     available at merge time (which original cell was refined and how its
@@ -316,9 +353,9 @@ def create_nested_hybrid_grid(
         refinement: ``(ncol, nrow, nlay)`` refinement factors.
 
     Returns:
-        A tuple ``(merged_grid, nnc_table)`` where *merged_grid* is a new
-        :class:`xtgeo.Grid` with the refined region stitched back into the
-        coarse grid and *nnc_table* is a :class:`pandas.DataFrame` mapping
+        A tuple ``(merged_grid, nnc_table)`` where *merged_grid*
+        is a new :class:`xtgeo.Grid` with the refined region stitched back into
+        the coarse grid and *nnc_table* is a :class:`pandas.DataFrame` mapping
         mother cells to their connected refined cells.
     """
     if any(r < 1 for r in refinement):
@@ -343,10 +380,19 @@ def create_nested_hybrid_grid(
     # 2. Refine the cropped grid.
     refined = cropped.copy()
     rcol, rrow, rlay = refinement
+    _, _, olay = crop_origin
     refined.refine(refine_col=rcol, refine_row=rrow, refine_layer=rlay)
     _logger.info("Refined cropped grid dimensions: %s", refined.dimensions)
 
-    # 3. Compute the NNC mapping table *before* deactivation mutates anything.
+    # 3. Generate layer mappings
+    lmap1, lmap2 = _generate_layer_mappings(
+        coarse_nlay=grid.nlay,
+        refined_nlay=refined.nlay,
+        crop_origin=crop_origin,
+        refinement=refinement,
+    )
+
+    # 4. Compute the NNC mapping table *before* deactivation mutates anything.
     #    This uses the original region property to find boundary faces and
     #    maps them through the crop → refine → merge index chain.
     nnc_table = _compute_nnc_table(
@@ -355,37 +401,20 @@ def create_nested_hybrid_grid(
         crop_origin=crop_origin,
         refinement=refinement,
         coarse_ncol=grid.ncol,
+        lmap1=lmap1,
+        lmap2=lmap2,
     )
 
-    # 4. Deactivate the target region in the coarse grid (will be replaced).
+    # 5. Deactivate the target region in the coarse grid (will be replaced).
     coarse_region = grid.get_prop_by_name(region.name)
     _set_actnum_by_region(grid, coarse_region, target_region_id, invert=False)
 
-    # 5. In the refined grid keep only target-region cells active.
+    # 6. In the refined grid keep only target-region cells active.
     refined_region = refined.get_prop_by_name(region.name)
     _set_actnum_by_region(refined, refined_region, target_region_id, invert=True)
 
-    # 6. Create NEST_ID properties before merging (1=mother, 2=refined).
-    nest_id_coarse = xtgeo.GridProperty(
-        grid,
-        name="NEST_ID",
-        discrete=True,
-        values=np.where(grid.get_actnum().values == 1, 1, 0).astype(np.int32),
-        codes={0: "inactive", 1: "mother", 2: "refined"},
-    )
-    grid.append_prop(nest_id_coarse)
-
-    nest_id_refined = xtgeo.GridProperty(
-        refined,
-        name="NEST_ID",
-        discrete=True,
-        values=np.where(refined.get_actnum().values == 1, 2, 0).astype(np.int32),
-        codes={0: "inactive", 1: "mother", 2: "refined"},
-    )
-    refined.append_prop(nest_id_refined)
-
     # 7. Merge the two grids.
-    merged = xtgeo.grid_merge(grid, refined)
+    merged = xtgeo.grid_merge(grid, refined, lmap1, lmap2)
     _logger.info("Merged grid dimensions: %s", merged.dimensions)
 
     return merged, nnc_table

--- a/tests/nestedhybridgrid/test_nestedhybrid.py
+++ b/tests/nestedhybridgrid/test_nestedhybrid.py
@@ -283,6 +283,18 @@ class TestCreateNestedHybridGrid:
                 upscaling=(ui, uj, uk),
             )
 
+    def test_zonation(self):
+        """Function must return an xtgeo.Grid."""
+        grid, region, rid = _make_box_grid_with_region(dimension=(6, 6, 2))
+        grid.subgrids = {"ZONE1": [1], "ZONE2": [2]}
+        merged, nnc_table, _ = create_nested_hybrid_grid(
+            grid, region, rid, refinement=(2, 2, 2)
+        )
+        subgrids = merged.get_subgrids()
+
+        assert subgrids["ZONE1"] == 2
+        assert subgrids["ZONE2"] == 2
+
 
 # ---------------------------------------------------------------------------
 # Tests for get_transmissibilities with nested hybrid NNCs

--- a/tests/nestedhybridgrid/test_nestedhybrid.py
+++ b/tests/nestedhybridgrid/test_nestedhybrid.py
@@ -10,6 +10,9 @@ from fmu.tools.nestedhybridgrid import (
     nnc_to_flowsimulator_input,
     nnc_to_gridproperty,
 )
+from fmu.tools.nestedhybridgrid.nestedhybrid import (
+    _generate_layer_mappings,
+)
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -77,11 +80,11 @@ class TestCreateNestedHybridGrid:
         assert merged.nlay >= grid.nlay
 
     def test_nest_id_property_attached(self):
-        """The merged grid must have a NEST_ID property."""
+        """The merged grid must have a refinement region property."""
         grid, region, rid = _make_box_grid_with_region(dimension=(6, 6, 2))
         merged, _ = create_nested_hybrid_grid(grid, region, rid, refinement=(1, 1, 1))
 
-        nest_id = merged.get_prop_by_name("NEST_ID")
+        nest_id = merged.get_prop_by_name(region.name)
         assert nest_id is not None
         unique_vals = set(np.unique(np.ma.filled(nest_id.values, fill_value=0)))
         # Must contain at least mother (1) and refined (2) cells
@@ -89,11 +92,11 @@ class TestCreateNestedHybridGrid:
         assert 2 in unique_vals
 
     def test_nest_id_values_consistent(self):
-        """Active cells should only have NEST_ID in {1, 2}."""
+        """Active cells should only have refinement region in {1, 2}."""
         grid, region, rid = _make_box_grid_with_region(dimension=(6, 6, 2))
         merged, _ = create_nested_hybrid_grid(grid, region, rid, refinement=(1, 1, 1))
 
-        nest_id = merged.get_prop_by_name("NEST_ID")
+        nest_id = merged.get_prop_by_name(region.name)
         actnum = merged.get_actnum()
 
         active_mask = actnum.values == 1
@@ -125,11 +128,75 @@ class TestCreateNestedHybridGrid:
         orig_nactive = grid.nactive
         orig_region_sum = int(np.ma.filled(region.values, 0).sum())
 
-        _ = create_nested_hybrid_grid(grid, region, rid, refinement=(2, 2, 1))
+        _, _ = create_nested_hybrid_grid(grid, region, rid, refinement=(2, 2, 1))
 
         assert grid.ncol == orig_ncol
         assert grid.nactive == orig_nactive
         assert int(np.ma.filled(region.values, 0).sum()) == orig_region_sum
+
+    def test_lmap_via_nnc(self):
+        """Test correct lmaps generated indirectly via nnc_table.
+        Cells in nnc_table for layer number completely controlled by lmap.
+        """
+        grid, region, rid = _make_box_grid_with_region(dimension=(3, 3, 3))
+
+        region.values = np.ones(region.values.shape)
+        region.values[1][1][1] = rid
+
+        _, nnc_table = create_nested_hybrid_grid(
+            grid, region, rid, refinement=(2, 2, 2)
+        )
+        nnc_table1 = nnc_table[
+            (nnc_table["I1"] == 2)
+            & (nnc_table["J1"] == 1)
+            & (nnc_table["I2"] == 5)
+            & (nnc_table["J2"] == 1)
+        ]
+
+        assert nnc_table1[(nnc_table1["K1"] == 2) & (nnc_table1["K2"] == 2)].shape == (
+            1,
+            7,
+        )
+        assert nnc_table1[(nnc_table1["K1"] == 2) & (nnc_table1["K2"] == 3)].shape == (
+            1,
+            7,
+        )
+        assert nnc_table1[(nnc_table1["K1"] == 3) & (nnc_table1["K2"] == 2)].shape == (
+            0,
+            7,
+        )
+
+    def test_lmap_generation_simple(self):
+        """Tests that the correct layer mappings are generated"""
+
+        lmap1, lmap2 = _generate_layer_mappings(3, 2, (2, 2, 2), (1, 1, 1))
+
+        assert np.array_equal(lmap1, np.array([0, 1, 3]))
+        assert np.array_equal(lmap2, np.array([1, 2]))
+
+    def test_lmap_generation_no_offset(self):
+        """Tests that the correct layer mappings are generated"""
+
+        lmap1, lmap2 = _generate_layer_mappings(3, 4, (2, 2, 2), (1, 1, 0))
+
+        assert np.array_equal(lmap1, np.array([0, 2, 4]))
+        assert np.array_equal(lmap2, np.array([0, 1, 2, 3]))
+
+    def test_lmap_generation_full_offset(self):
+        """Tests that the correct layer mappings are generated"""
+
+        lmap1, lmap2 = _generate_layer_mappings(3, 4, (2, 2, 2), (1, 1, 3))
+
+        assert np.array_equal(lmap1, np.array([0, 1, 2]))
+        assert np.array_equal(lmap2, np.array([3, 4, 5, 6]))
+
+    def test_lmap_generation_ref10(self):
+        """Tests that the correct layer mappings are generated"""
+
+        lmap1, lmap2 = _generate_layer_mappings(3, 20, (2, 2, 10), (1, 1, 1))
+
+        assert np.array_equal(lmap1, np.array([0, 1, 11]))
+        assert np.array_equal(lmap2, np.arange(20) + 1)
 
 
 # ---------------------------------------------------------------------------
@@ -138,7 +205,7 @@ class TestCreateNestedHybridGrid:
 
 
 class TestTransmissibilitiesOnMergedGrid:
-    """Test calling get_transmissibilities on the merged grid with NEST_ID."""
+    """Test calling get_transmissibilities on the merged grid"""
 
     @staticmethod
     def _build_merged_with_props(dimension=(6, 6, 2), refinement=(1, 1, 1)):

--- a/tests/nestedhybridgrid/test_nestedhybrid.py
+++ b/tests/nestedhybridgrid/test_nestedhybrid.py
@@ -51,6 +51,52 @@ def _make_constant_property(grid, name, value):
     return xtgeo.GridProperty(grid, name=name, values=vals)
 
 
+def _upscale_test_setup():
+    """Create grids and properties to test upscaling."""
+
+    grid = xtgeo.create_box_grid((3, 3, 3), increment=(100.0, 100.0, 20.0))
+    geogrid = xtgeo.create_box_grid((6, 6, 6), increment=(50.0, 50.0, 10.0))
+
+    region = _make_constant_property(grid, "REGION", 1)
+    region.values[1][1][1] = 2
+
+    rid = 2
+
+    il2 = (np.repeat(np.arange(3, dtype=np.float32), 3 * 3)).reshape((3, 3, 3)) + 1
+    il2 = np.repeat(il2, 2, axis=0)
+    il2 = np.repeat(il2, 2, axis=1)
+    il2 = np.repeat(il2, 2, axis=2)
+    ui = xtgeo.GridProperty(geogrid, name="UI", values=il2.astype(np.float32))
+
+    jl2 = (
+        np.swapaxes(
+            (np.repeat(np.arange(3, dtype=np.float32), 3 * 3)).reshape((3, 3, 3)),
+            0,
+            1,
+        )
+        + 1
+    )
+    jl2 = np.repeat(jl2, 2, axis=0)
+    jl2 = np.repeat(jl2, 2, axis=1)
+    jl2 = np.repeat(jl2, 2, axis=2)
+    uj = xtgeo.GridProperty(geogrid, name="UJ", values=jl2.astype(np.float32))
+
+    kl2 = (
+        np.swapaxes(
+            (np.repeat(np.arange(3, dtype=np.float32), 3 * 3)).reshape((3, 3, 3)),
+            0,
+            2,
+        )
+        + 1
+    )
+    kl2 = np.repeat(kl2, 2, axis=0)
+    kl2 = np.repeat(kl2, 2, axis=1)
+    kl2 = np.repeat(kl2, 2, axis=2)
+    uk = xtgeo.GridProperty(geogrid, name="UK", values=kl2.astype(np.float32))
+
+    return (grid, region, rid, geogrid, ui, uj, uk)
+
+
 # ---------------------------------------------------------------------------
 # Tests for create_nested_hybrid_grid
 # ---------------------------------------------------------------------------
@@ -62,7 +108,7 @@ class TestCreateNestedHybridGrid:
     def test_returns_grid(self):
         """Function must return an xtgeo.Grid."""
         grid, region, rid = _make_box_grid_with_region(dimension=(6, 6, 2))
-        merged, nnc_table = create_nested_hybrid_grid(
+        merged, nnc_table, _ = create_nested_hybrid_grid(
             grid, region, rid, refinement=(1, 1, 1)
         )
         assert isinstance(merged, xtgeo.Grid)
@@ -71,7 +117,9 @@ class TestCreateNestedHybridGrid:
     def test_basic_merge_dimensions(self):
         """Merged grid should have expected dimensions."""
         grid, region, rid = _make_box_grid_with_region(dimension=(6, 6, 2))
-        merged, _ = create_nested_hybrid_grid(grid, region, rid, refinement=(1, 1, 1))
+        merged, _, _ = create_nested_hybrid_grid(
+            grid, region, rid, refinement=(1, 1, 1)
+        )
 
         # grid_merge places grid2 with a 1-column gap:
         # ncol = grid1.ncol + 1 + grid2.ncol
@@ -82,7 +130,9 @@ class TestCreateNestedHybridGrid:
     def test_nest_id_property_attached(self):
         """The merged grid must have a refinement region property."""
         grid, region, rid = _make_box_grid_with_region(dimension=(6, 6, 2))
-        merged, _ = create_nested_hybrid_grid(grid, region, rid, refinement=(1, 1, 1))
+        merged, _, _ = create_nested_hybrid_grid(
+            grid, region, rid, refinement=(1, 1, 1)
+        )
 
         nest_id = merged.get_prop_by_name(region.name)
         assert nest_id is not None
@@ -94,7 +144,9 @@ class TestCreateNestedHybridGrid:
     def test_nest_id_values_consistent(self):
         """Active cells should only have refinement region in {1, 2}."""
         grid, region, rid = _make_box_grid_with_region(dimension=(6, 6, 2))
-        merged, _ = create_nested_hybrid_grid(grid, region, rid, refinement=(1, 1, 1))
+        merged, _, _ = create_nested_hybrid_grid(
+            grid, region, rid, refinement=(1, 1, 1)
+        )
 
         nest_id = merged.get_prop_by_name(region.name)
         actnum = merged.get_actnum()
@@ -106,10 +158,10 @@ class TestCreateNestedHybridGrid:
     def test_refinement_increases_cells(self):
         """Refinement > 1 should produce a merged grid with more total cells."""
         grid, region, rid = _make_box_grid_with_region(dimension=(6, 6, 2))
-        merged_1x, _ = create_nested_hybrid_grid(
+        merged_1x, _, _ = create_nested_hybrid_grid(
             grid, region, rid, refinement=(1, 1, 1)
         )
-        merged_2x, _ = create_nested_hybrid_grid(
+        merged_2x, _, _ = create_nested_hybrid_grid(
             grid, region, rid, refinement=(2, 2, 2)
         )
         assert merged_2x.ntotal > merged_1x.ntotal
@@ -128,7 +180,7 @@ class TestCreateNestedHybridGrid:
         orig_nactive = grid.nactive
         orig_region_sum = int(np.ma.filled(region.values, 0).sum())
 
-        _, _ = create_nested_hybrid_grid(grid, region, rid, refinement=(2, 2, 1))
+        _, _, _ = create_nested_hybrid_grid(grid, region, rid, refinement=(2, 2, 1))
 
         assert grid.ncol == orig_ncol
         assert grid.nactive == orig_nactive
@@ -143,7 +195,7 @@ class TestCreateNestedHybridGrid:
         region.values = np.ones(region.values.shape)
         region.values[1][1][1] = rid
 
-        _, nnc_table = create_nested_hybrid_grid(
+        _, nnc_table, _ = create_nested_hybrid_grid(
             grid, region, rid, refinement=(2, 2, 2)
         )
         nnc_table1 = nnc_table[
@@ -198,6 +250,39 @@ class TestCreateNestedHybridGrid:
         assert np.array_equal(lmap1, np.array([0, 1, 11]))
         assert np.array_equal(lmap2, np.arange(20) + 1)
 
+    def test_upscaling(self):
+        """test upscaling only modified in refined region"""
+
+        (grid, region, rid, geogrid, ui, uj, uk) = _upscale_test_setup()
+
+        _, _, upscaled = create_nested_hybrid_grid(
+            grid, region, rid, refinement=(2, 2, 2), upscaling=(ui, uj, uk)
+        )
+
+        upi, upj, upk = upscaled
+
+        assert upi.values[0][0][0] == 1
+        assert upj.values[0][0][0] == 1
+        assert upk.values[0][0][0] == 1
+        assert upi.values[2][2][2] == 5
+        assert upk.values[2][2][2] == 2
+        assert upj.values[3][3][3] == 2
+
+    def test_upscaling_ranges(self):
+        """test upscaling only modified in refined region"""
+
+        (grid, region, rid, geogrid, ui, uj, uk) = _upscale_test_setup()
+
+        ui.values = ui.values - 2
+        with pytest.raises(ValueError, match="Invalid input upscaling relationships"):
+            create_nested_hybrid_grid(
+                grid,
+                region,
+                rid,
+                refinement=(2, 2, 2),
+                upscaling=(ui, uj, uk),
+            )
+
 
 # ---------------------------------------------------------------------------
 # Tests for get_transmissibilities with nested hybrid NNCs
@@ -211,7 +296,7 @@ class TestTransmissibilitiesOnMergedGrid:
     def _build_merged_with_props(dimension=(6, 6, 2), refinement=(1, 1, 1)):
         """Helper: build merged grid and attach constant perm/ntg properties."""
         grid, region, rid = _make_box_grid_with_region(dimension=dimension)
-        merged, nnc_table = create_nested_hybrid_grid(
+        merged, nnc_table, _ = create_nested_hybrid_grid(
             grid, region, rid, refinement=refinement
         )
 


### PR DESCRIPTION
Supports zonation with nested hybrid grid creation

Tracks and generates upscaling correspondences for nested hybrid grid. Takes an optional valid input mapping and returns an updated version mapping to the merged grid.

TESTS + DOCUMENATION to be added. Getting the core functionality updated and shared following from discussions today. I'll try to add them tomorrow and respond to any comments then. Will rebase and squash before merge.

## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [ ] If not squash merging, every commit passes tests
- [ ] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [ ] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [ ] Moved issue status on project board
- [ ] Checked the boxes in this checklist ✅
