### PR TITLE
ENH: nested grid with optional upscaling mappings

### DIFF
--- a/docs/nestedhybridgrid.rst
+++ b/docs/nestedhybridgrid.rst
@@ -69,7 +69,11 @@ The example here runs within RMS, but similar workflows can be created for file 
 
 
 The next step is to do a rescaling from the original geogrid to the merged grid
-using e.g. the RMS tool.
+using e.g. the RMS tool. Optionally the create_nested_hybrid_grid_upscale job can be used
+instead to also update upscaling mappings. This takes an additional input upscaling as a
+tuple of valid :class:`~xtgeo.GridProperty` (i,j,k) that maps from the geogrid to the input
+grid. This also returns a third value; a tuple of :class:`~xtgeo.GridProperty` with the 
+updated mappings.
 
 Further, we need to create NNC transmissibilities and generate file for flow simulator:
 

--- a/src/fmu/tools/nestedhybridgrid/nestedhybrid.py
+++ b/src/fmu/tools/nestedhybridgrid/nestedhybrid.py
@@ -79,6 +79,23 @@ class Refinement(BaseModel):
             raise ValueError("Refinement factors must be >= 1")
 
 
+class Upscale(BaseModel):
+    imap: xtgeo.GridProperty
+    jmap: xtgeo.GridProperty
+    kmap: xtgeo.GridProperty
+
+    class Config:
+        arbitrary_types_allowed = True
+
+    @classmethod
+    def from_tuple(
+        cls,
+        upscaling: tuple[xtgeo.GridProperty, xtgeo.GridProperty, xtgeo.GridProperty],
+    ) -> Self:
+        imap2, jmap2, kmap2 = upscaling
+        return cls(imap=imap2, jmap=jmap2, kmap=kmap2)
+
+
 def _crop_for_region(grid: xtgeo.Grid, refinement_bbox: BoundingBox) -> xtgeo.Grid:
     """Crop grid to the bounding box of the refinement region."""
 
@@ -282,6 +299,158 @@ def _set_actnum_in_grid(grid: xtgeo.Grid, active_mask: np.ndarray) -> None:
     grid.set_actnum(actnum)
 
 
+def _modify_upscaling_mapping(
+    up: Upscale,
+    region: xtgeo.GridProperty,
+    target_region_id: int,
+    refinement: Refinement,
+    offset: BoundingBox,
+    lmap: np.ndarray,
+) -> Upscale:
+    """
+    Generate an updated version of the upscaling mapping. Converting the input
+    mappings given to reflect the new final merged grid.
+    """
+
+    imapi = up.imap
+    jmapi = up.jmap
+    kmapi = up.kmap
+    oi = offset.imin - 1
+    oj = offset.jmin - 1
+    ok = offset.kmin - 1
+    ri = refinement.col
+    rj = refinement.row
+    rk = refinement.lay
+    di = (offset.imax - oi) * ri
+    dj = (offset.jmax - oj) * rj
+    dk = (offset.kmax - ok) * rk
+
+    imap = imapi.copy()
+    jmap = jmapi.copy()
+    kmap = kmapi.copy()
+
+    ivm = region.ncol
+    jvm = region.nrow
+    kvm = region.nlay
+
+    iv = imapi.values.reshape(-1) - 1
+    jv = jmapi.values.reshape(-1) - 1
+    kv = kmapi.values.reshape(-1) - 1
+
+    if (
+        iv.min() < -1
+        or jv.min() < -1
+        or kv.min() < -1
+        or iv.max() >= region.ncol
+        or jv.max() >= region.nrow
+        or kv.max() >= region.nlay
+    ):
+        raise ValueError("Invalid input upscaling relationships")
+
+    exclude_mask = (iv == -1) | (jv == -1) | (kv == -1)
+
+    # map region from input grid to geogrid
+    # excluding any enteries for cells in geogrid that are excluded
+    cn = np.ma.masked_where(exclude_mask, iv * jvm * kvm + jv * kvm + kv)
+    # mask any inactive cells in the input grid that are mapped by geogrid
+    iv[~cn.mask][region.values.mask.reshape(-1)[cn[~cn.mask].astype(np.int32)]] = -1
+    jv[~cn.mask][region.values.mask.reshape(-1)[cn[~cn.mask].astype(np.int32)]] = -1
+    kv[~cn.mask][region.values.mask.reshape(-1)[cn[~cn.mask].astype(np.int32)]] = -1
+    exclude_mask = (iv == -1) | (jv == -1) | (kv == -1)
+    cn = np.ma.masked_where(exclude_mask, cn)
+
+    region2 = np.ma.MaskedArray(np.zeros(len(cn)), mask=cn.mask, dtype=np.int32)
+    region2[~cn.mask] = region.values.reshape(-1)[cn[~cn.mask].astype(np.int32)].astype(
+        np.int32
+    )
+
+    # for cells that aren't refined only layer numbering updates
+    kv[(~cn.mask) & (region2 != target_region_id)] = lmap[
+        kv[(~cn.mask) & (region2 != target_region_id)].astype(np.int32)
+    ]
+
+    # for cells that are refined find the levels of refinement
+    cijk = np.argwhere(region.values == target_region_id)
+    cijk2 = np.argwhere(region2.reshape(imap.values.shape) == target_region_id)
+    cnr = cijk[:, 0] * jvm * kvm + cijk[:, 1] * kvm + cijk[:, 2]
+
+    # find number of cells in refined region on geogrid and normal grid
+    ccnt = [len(np.unique(cijk[:, x])) for x in range(3)]
+    ccnt2 = [len(np.unique(cijk2[:, x])) for x in range(3)]
+
+    uri = ccnt2[0] / ccnt[0]
+    urj = ccnt2[1] / ccnt[1]
+    urk = ccnt2[2] / ccnt[2]
+
+    if any(not x.is_integer() for x in [uri, uri / ri, urj, urj / rj, urk, urk / rk]):
+        raise ValueError(
+            "Invalid correspondence upscaling between geogrid and input grid"
+        )
+
+    # original index map of refined cells
+    il2 = (
+        np.repeat(np.arange(int(di / ri), dtype=np.int32) + oi, ri * dj * dk)
+    ).reshape((di, dj, dk))
+    jl2 = np.swapaxes(
+        (np.repeat(np.arange(int(dj / rj), dtype=np.int32) + oj, rj * di * dk)).reshape(
+            (dj, di, dk)
+        ),
+        0,
+        1,
+    )
+    kl2 = np.swapaxes(
+        (np.repeat(np.arange(int(dk / rk), dtype=np.int32) + ok, rk * di * dj)).reshape(
+            (dk, dj, di)
+        ),
+        0,
+        2,
+    )
+    # map the updated refined grid cells to geogrid
+    cmap2 = np.arange(di, dtype=np.float32) + ivm + 1
+    cmap2 = np.repeat(cmap2, dj * dk).reshape((di, dj, dk))
+    rmap2 = np.arange(dj, dtype=np.float32)
+    rmap2 = np.swapaxes(np.repeat(rmap2, di * dk).reshape((dj, di, dk)), 0, 1)
+    lmap2 = np.arange(dk, dtype=np.float32) + ok
+    lmap2 = np.tile(lmap2, di * dj).reshape((di, dj, dk))
+
+    if uri > ri:
+        il2 = np.repeat(il2, int(uri / ri), axis=0)
+        jl2 = np.repeat(jl2, int(uri / ri), axis=0)
+        kl2 = np.repeat(kl2, int(uri / ri), axis=0)
+        cmap2 = np.repeat(cmap2, int(uri / ri), axis=0)
+        rmap2 = np.repeat(rmap2, int(uri / ri), axis=0)
+        lmap2 = np.repeat(lmap2, int(uri / ri), axis=0)
+    if urj > rj:
+        il2 = np.repeat(il2, int(urj / rj), axis=1)
+        jl2 = np.repeat(jl2, int(urj / rj), axis=1)
+        kl2 = np.repeat(kl2, int(urj / rj), axis=1)
+        cmap2 = np.repeat(cmap2, int(urj / rj), axis=1)
+        rmap2 = np.repeat(rmap2, int(urj / rj), axis=1)
+        lmap2 = np.repeat(lmap2, int(urj / rj), axis=1)
+    if urk > rk:
+        il2 = np.repeat(il2, int(urk / rk), axis=2)
+        jl2 = np.repeat(jl2, int(urk / rk), axis=2)
+        kl2 = np.repeat(kl2, int(urk / rk), axis=2)
+        cmap2 = np.repeat(cmap2, int(urk / rk), axis=2)
+        rmap2 = np.repeat(rmap2, int(urk / rk), axis=2)
+        lmap2 = np.repeat(lmap2, int(urk / rk), axis=2)
+
+    cl2 = il2.reshape(-1) * jvm * kvm + jl2.reshape(-1) * kvm + kl2.reshape(-1)
+
+    # ensure only correct cells are updated
+    geomask = region2 == target_region_id
+    refmask = np.isin(cl2, cnr)
+    iv[geomask] = cmap2.reshape(-1)[refmask]
+    jv[geomask] = rmap2.reshape(-1)[refmask]
+    kv[geomask] = lmap2.reshape(-1)[refmask]
+
+    imap.values = iv.reshape(imap.values.shape).astype(np.float32) + 1.0
+    jmap.values = jv.reshape(imap.values.shape).astype(np.float32) + 1.0
+    kmap.values = kv.reshape(imap.values.shape).astype(np.float32) + 1.0
+
+    return Upscale.from_tuple((imap, jmap, kmap))
+
+
 # ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
@@ -301,6 +470,8 @@ class NestedHybridGrid:
         region: xtgeo.GridProperty,
         refinement: tuple[int, int, int],
         target_region_id: int = 1,
+        upscaling: tuple[xtgeo.GridProperty, xtgeo.GridProperty, xtgeo.GridProperty]
+        | None = None,
     ) -> None:
         """Create a NestedHybridGrid instance."""
 
@@ -308,6 +479,8 @@ class NestedHybridGrid:
 
         self._nnc_table: pd.DataFrame | None = None
         self._grid: xtgeo.Grid | None = None
+        self._upscale: Upscale | None = None
+        self._upscaled: Upscale | None = None
 
         self._original_grid = coarse_grid
         self._original_dimensions = coarse_grid.dimensions
@@ -323,6 +496,9 @@ class NestedHybridGrid:
 
         self._layer_map_coarse = self._generate_layer_map_coarse()
         self._layer_map_refined = self._generate_layer_map_refined()
+
+        if upscaling is not None:
+            self._upscale = Upscale.from_tuple(upscaling)
 
     @staticmethod
     def _validate_inputs(
@@ -403,6 +579,15 @@ class NestedHybridGrid:
             self._nnc_table = self._compute_nnc_table()
         return self._nnc_table
 
+    @property
+    def upscale_map(
+        self,
+    ) -> tuple[xtgeo.GridProperty, xtgeo.GridProperty, xtgeo.GridProperty]:
+        """updated upscaling mappings from geogrid to final merged grid."""
+        if self._upscaled is None:
+            self._upscaled = self._update_upscaling()
+        return (self._upscaled.imap, self._upscaled.jmap, self._upscaled.kmap)
+
     def _compute_nnc_table(self) -> pd.DataFrame:
         """Compute the NNC mapping table."""
         return _compute_nnc_table(
@@ -443,6 +628,21 @@ class NestedHybridGrid:
         """Get the number of layers of the refined grid."""
         bbox = self._refined_bbox
         return (bbox.kmax - bbox.kmin + 1) * self._refinement.lay
+
+    def _update_upscaling(
+        self,
+    ) -> Upscale:
+        """Update the upscaling mapping"""
+        if self._upscale is None:
+            raise ValueError("No input data given for upscaling.")
+        return _modify_upscaling_mapping(
+            self._upscale,
+            self._original_region,
+            self._target_region_id,
+            self._refinement,
+            self._refined_bbox,
+            self._layer_map_coarse,
+        )
 
     def _set_zonation(self, nlay: int) -> dict | None:
         """Create an updated subgrid dictionary for the merged grid."""
@@ -526,6 +726,76 @@ def create_nested_hybrid_grid(
     )
 
     return nhg.grid, nhg.nnc_table
+
+
+def create_nested_hybrid_grid_upscale(
+    grid: xtgeo.Grid,
+    region: xtgeo.GridProperty,
+    target_region_id: int,
+    refinement: tuple[int, int, int],
+    upscaling: tuple[xtgeo.GridProperty, xtgeo.GridProperty, xtgeo.GridProperty],
+) -> tuple[
+    xtgeo.Grid,
+    pd.DataFrame,
+    tuple[xtgeo.GridProperty, xtgeo.GridProperty, xtgeo.GridProperty],
+]:
+    """Create a nested hybrid grid by refining one region and merging it back.
+
+    The cells belonging to *target_region_id* are replaced by a refined
+    (subdivided) version of the same region.
+
+    A **NNC mapping table** is returned that lists every
+    mother ↔ refined cell pair that should be connected by a Non-Neighbour
+    Connection (NNC).  The table is derived from the topological knowledge
+    available at merge time (which original cell was refined and how its
+    sub-cells map into the merged grid).
+
+    The table columns are:
+
+    - ``I1, J1, K1``: mother cell indices (1-based) in the merged grid.
+    - ``I2, J2, K2``: refined cell indices (1-based) in the merged grid.
+    - ``DIRECTION``: face direction from the mother cell's perspective
+      (``I+``, ``I-``, ``J+``, ``J-``, ``K+``, ``K-``).
+
+    This table can be passed to
+    :meth:`xtgeo.Grid.get_transmissibilities` to compute NNC
+    transmissibilities for the specified cell pairs.
+
+    Args:
+        grid: The original coarse grid.
+        region: A :class:`xtgeo.GridProperty` whose values identify the
+            regions (e.g. an integer region parameter).
+        target_region_id: The region value to refine.
+        refinement: ``(ncol, nrow, nlay)`` refinement factors.
+        upscaling: Optional tuple of `xtgeo.GridProperty` for (I,J,K)
+            Geogrid properties. These map from geogrid cell to input grid
+            The input values must be a valid mapping for upscaling from
+            the geogrid to the input grid give. A value of 0 can be used
+            to exclude the geogrid cell from upscaling
+
+    Returns:
+        A tuple ``(merged_grid, nnc_table)`` where *merged_grid*
+        is a new :class:`xtgeo.Grid` with the refined region stitched back into
+        the coarse grid and *nnc_table* is a :class:`pandas.DataFrame` mapping
+        mother cells to their connected refined cells. Upscaling tuple is a tuple
+        with 3 :class:`xtgeo.GridProperty` (I, J, K) with the updated mapping
+        from geogrid to merged grid for upscaling.
+    """
+    warnings.warn(
+        "create_nested_hybrid_grid_upscale is currently experimental. It may "
+        " undergo breaking changes in future versions without notice.",
+        FutureWarning,
+    )
+
+    nhg = NestedHybridGrid(
+        coarse_grid=grid,
+        region=region,
+        refinement=refinement,
+        target_region_id=target_region_id,
+        upscaling=upscaling,
+    )
+
+    return nhg.grid, nhg.nnc_table, nhg.upscale_map
 
 
 def nnc_to_gridproperty(

--- a/tests/nestedhybridgrid/test_nestedhybrid.py
+++ b/tests/nestedhybridgrid/test_nestedhybrid.py
@@ -50,6 +50,52 @@ def _make_constant_property(grid, name, value):
     return xtgeo.GridProperty(grid, name=name, values=vals)
 
 
+def _upscale_test_setup():
+    """Create grids and properties to test upscaling."""
+
+    grid = xtgeo.create_box_grid((3, 3, 3), increment=(100.0, 100.0, 20.0))
+    geogrid = xtgeo.create_box_grid((6, 6, 6), increment=(50.0, 50.0, 10.0))
+
+    region = _make_constant_property(grid, "REGION", 1)
+    region.values[1][1][1] = 2
+
+    rid = 2
+
+    il2 = (np.repeat(np.arange(3, dtype=np.float32), 3 * 3)).reshape((3, 3, 3)) + 1
+    il2 = np.repeat(il2, 2, axis=0)
+    il2 = np.repeat(il2, 2, axis=1)
+    il2 = np.repeat(il2, 2, axis=2)
+    ui = xtgeo.GridProperty(geogrid, name="UI", values=il2.astype(np.float32))
+
+    jl2 = (
+        np.swapaxes(
+            (np.repeat(np.arange(3, dtype=np.float32), 3 * 3)).reshape((3, 3, 3)),
+            0,
+            1,
+        )
+        + 1
+    )
+    jl2 = np.repeat(jl2, 2, axis=0)
+    jl2 = np.repeat(jl2, 2, axis=1)
+    jl2 = np.repeat(jl2, 2, axis=2)
+    uj = xtgeo.GridProperty(geogrid, name="UJ", values=jl2.astype(np.float32))
+
+    kl2 = (
+        np.swapaxes(
+            (np.repeat(np.arange(3, dtype=np.float32), 3 * 3)).reshape((3, 3, 3)),
+            0,
+            2,
+        )
+        + 1
+    )
+    kl2 = np.repeat(kl2, 2, axis=0)
+    kl2 = np.repeat(kl2, 2, axis=1)
+    kl2 = np.repeat(kl2, 2, axis=2)
+    uk = xtgeo.GridProperty(geogrid, name="UK", values=kl2.astype(np.float32))
+
+    return (grid, region, rid, geogrid, ui, uj, uk)
+
+
 def test_set_actnum_in_grid_deactivates_cells_where_mask_is_false():
     """Cells with active_mask=False should have actnum set to 0."""
     grid = xtgeo.create_box_grid((3, 3, 2))
@@ -555,6 +601,208 @@ class TestNestedHybridGridClass:
 
         assert np.array_equal(lmap1, np.array([0, 1, 11]))
         assert np.array_equal(lmap2, np.arange(20) + 1)
+
+    def test_upscaling_no_input(self):
+        """test upscaling output is None for no input"""
+
+        (grid, region, rid, geogrid, ui, uj, uk) = _upscale_test_setup()
+
+        with pytest.raises(ValueError, match="No input data given for upscaling."):
+            nhg = NestedHybridGrid(
+                coarse_grid=grid,
+                region=region,
+                refinement=(2, 2, 2),
+                target_region_id=rid,
+            )
+            nhg.upscale_map
+
+    def test_upscaling_ranges_i_min(self):
+        """test upscaling raises error if ui<0"""
+
+        (grid, region, rid, geogrid, ui, uj, uk) = _upscale_test_setup()
+
+        ui.values = ui.values - 2
+        with pytest.raises(ValueError, match="Invalid input upscaling relationships"):
+            nhg = NestedHybridGrid(
+                coarse_grid=grid,
+                region=region,
+                refinement=(2, 2, 2),
+                target_region_id=rid,
+                upscaling=(ui, uj, uk),
+            )
+            nhg.upscale_map
+
+    def test_upscaling_ranges_i_max(self):
+        """test upscaling raises error if ui>grid.ncol"""
+
+        (grid, region, rid, geogrid, ui, uj, uk) = _upscale_test_setup()
+
+        ui.values = ui.values + 2
+        with pytest.raises(ValueError, match="Invalid input upscaling relationships"):
+            nhg = NestedHybridGrid(
+                coarse_grid=grid,
+                region=region,
+                refinement=(2, 2, 2),
+                target_region_id=rid,
+                upscaling=(ui, uj, uk),
+            )
+            nhg.upscale_map
+
+    def test_upscaling_ranges_j_min(self):
+        """test upscaling raises error if uj<0"""
+
+        (grid, region, rid, geogrid, ui, uj, uk) = _upscale_test_setup()
+
+        uj.values = uj.values - 2
+        with pytest.raises(ValueError, match="Invalid input upscaling relationships"):
+            nhg = NestedHybridGrid(
+                coarse_grid=grid,
+                region=region,
+                refinement=(2, 2, 2),
+                target_region_id=rid,
+                upscaling=(ui, uj, uk),
+            )
+            nhg.upscale_map
+
+    def test_upscaling_ranges_j_max(self):
+        """test upscaling raises error if uj>grid.nrow"""
+
+        (grid, region, rid, geogrid, ui, uj, uk) = _upscale_test_setup()
+
+        uj.values = uj.values + 2
+        with pytest.raises(ValueError, match="Invalid input upscaling relationships"):
+            nhg = NestedHybridGrid(
+                coarse_grid=grid,
+                region=region,
+                refinement=(2, 2, 2),
+                target_region_id=rid,
+                upscaling=(ui, uj, uk),
+            )
+            nhg.upscale_map
+
+    def test_upscaling_ranges_k_min(self):
+        """test upscaling raises error if uk<0"""
+
+        (grid, region, rid, geogrid, ui, uj, uk) = _upscale_test_setup()
+
+        uk.values = uk.values - 2
+        with pytest.raises(ValueError, match="Invalid input upscaling relationships"):
+            nhg = NestedHybridGrid(
+                coarse_grid=grid,
+                region=region,
+                refinement=(2, 2, 2),
+                target_region_id=rid,
+                upscaling=(ui, uj, uk),
+            )
+            nhg.upscale_map
+
+    def test_upscaling_ranges_k_max(self):
+        """test upscaling raises error if uk>grid.nlay"""
+
+        (grid, region, rid, geogrid, ui, uj, uk) = _upscale_test_setup()
+
+        uk.values = uk.values + 2
+        with pytest.raises(ValueError, match="Invalid input upscaling relationships"):
+            nhg = NestedHybridGrid(
+                coarse_grid=grid,
+                region=region,
+                refinement=(2, 2, 2),
+                target_region_id=rid,
+                upscaling=(ui, uj, uk),
+            )
+            nhg.upscale_map
+
+    def test_upscaling_ratio_i(self):
+        """test upscaling for incompatible i ratio of geogrid to input grid"""
+
+        (grid, region, rid, geogrid, ui, uj, uk) = _upscale_test_setup()
+        with pytest.raises(
+            ValueError,
+            match="Invalid correspondence upscaling between geogrid and input grid",
+        ):
+            nhg = NestedHybridGrid(
+                coarse_grid=grid,
+                region=region,
+                refinement=(3, 2, 2),
+                target_region_id=rid,
+                upscaling=(ui, uj, uk),
+            )
+            nhg.upscale_map
+
+    def test_upscaling_ratio_j(self):
+        """test upscaling for incompatible j ratio of geogrid to input grid"""
+
+        (grid, region, rid, geogrid, ui, uj, uk) = _upscale_test_setup()
+
+        with pytest.raises(
+            ValueError,
+            match="Invalid correspondence upscaling between geogrid and input grid",
+        ):
+            nhg = NestedHybridGrid(
+                coarse_grid=grid,
+                region=region,
+                refinement=(2, 3, 2),
+                target_region_id=rid,
+                upscaling=(ui, uj, uk),
+            )
+            nhg.upscale_map
+
+    def test_upscaling_ratio_k(self):
+        """test upscaling for incompatible k ratio of geogrid to input grid"""
+
+        (grid, region, rid, geogrid, ui, uj, uk) = _upscale_test_setup()
+
+        with pytest.raises(
+            ValueError,
+            match="Invalid correspondence upscaling between geogrid and input grid",
+        ):
+            nhg = NestedHybridGrid(
+                coarse_grid=grid,
+                region=region,
+                refinement=(2, 2, 3),
+                target_region_id=rid,
+                upscaling=(ui, uj, uk),
+            )
+            nhg.upscale_map
+
+    def test_upscaling_output(self):
+        """test upscaling output mapping"""
+
+        (grid, region, rid, geogrid, ui, uj, uk) = _upscale_test_setup()
+        nhg = NestedHybridGrid(
+            coarse_grid=grid,
+            region=region,
+            refinement=(2, 2, 2),
+            target_region_id=rid,
+            upscaling=(ui, uj, uk),
+        )
+        upi, upj, upk = nhg.upscale_map
+
+        # test i,j==0 not modified
+        assert np.array_equal(upi.values[0, :, :], ui.values[0, :, :])
+        assert np.array_equal(upi.values[:, 0, :], ui.values[:, 0, :])
+        assert np.array_equal(upi.values[:, :, 0], ui.values[:, :, 0])
+        assert np.array_equal(upj.values[0, :, :], uj.values[0, :, :])
+        assert np.array_equal(upj.values[:, 0, :], uj.values[:, 0, :])
+        assert np.array_equal(upj.values[:, :, 0], uj.values[:, :, 0])
+        # test i,j==-1 not modified
+        assert np.array_equal(upi.values[-1, :, :], ui.values[-1, :, :])
+        assert np.array_equal(upi.values[:, -1, :], ui.values[:, -1, :])
+        assert np.array_equal(upi.values[:, :, -1], ui.values[:, :, -1])
+        assert np.array_equal(upj.values[-1, :, :], uj.values[-1, :, :])
+        assert np.array_equal(upj.values[:, -1, :], uj.values[:, -1, :])
+        assert np.array_equal(upj.values[:, :, -1], uj.values[:, :, -1])
+        # test layer modified in unrefined area
+        kt = [1.0, 1.0, 2.0, 2.0, 4.0, 4.0]
+        assert np.array_equal(upk.values[0, 0, :], np.array(kt))
+        assert np.array_equal(upk.values[-1, -1, :], np.array(kt))
+        # test refined area
+        ti = [[5.0, 5.0], [5.0, 5.0]], [[6.0, 6.0], [6.0, 6.0]]
+        tj = [[1.0, 1.0], [2.0, 2.0]], [[1.0, 1.0], [2.0, 2.0]]
+        tk = [[2.0, 3.0], [2.0, 3.0]], [[2.0, 3.0], [2.0, 3.0]]
+        assert np.array_equal(upi.values[2:4, 2:4, 2:4], np.array(ti))
+        assert np.array_equal(upj.values[2:4, 2:4, 2:4], np.array(tj))
+        assert np.array_equal(upk.values[2:4, 2:4, 2:4], np.array(tk))
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Add optional input of upscaling mappings from a geogrid to the input grid. These are then updated to map to the resulting nested hybrid grid. For situations where the geogrid and input grid are not perfectly aligned in structure due to the differences in resolution. This ensures that a proper mapping between cells in geogrid to nested hybrid grid can be maintain when both are originally sourced from same grid.

Main documentation will likely include the addition of an example workflow in drogon after this is all finalised.

## Checklist

- [X] Tests added (if not, comment why)
- [X] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [X] If not squash merging, every commit passes tests
- [X] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [X] All debug prints and unnecessary comments removed
- [X] Docstrings are correct and updated
- [X] Documentation is updated, if necessary
- [X] Latest main rebased/merged into branch
- [X] Added comments on this PR where appropriate to help reviewers
- [?] Moved issue status on project board
- [X] Checked the boxes in this checklist ✅
