### PR TITLE
DOC: Add experimental flag to Nested Hybrid Grid module

### DIFF
--- a/docs/nestedhybridgrid.rst
+++ b/docs/nestedhybridgrid.rst
@@ -1,6 +1,12 @@
 Nested Hybrid Grids
 ====================
 
+.. admonition:: 🧪 Experimental Feature
+   :class: warning
+
+   This module is currently experimental. It may undergo breaking changes 
+   in future versions without notice.
+
 .. contents:: Table of Contents
    :local:
    :depth: 2

--- a/src/fmu/tools/nestedhybridgrid/nestedhybrid.py
+++ b/src/fmu/tools/nestedhybridgrid/nestedhybrid.py
@@ -17,6 +17,7 @@ nnc_to_flowsimulator_input : function
 from __future__ import annotations
 
 import logging
+import warnings
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -358,6 +359,11 @@ def create_nested_hybrid_grid(
         the coarse grid and *nnc_table* is a :class:`pandas.DataFrame` mapping
         mother cells to their connected refined cells.
     """
+    warnings.warn(
+        "create_nested_hybrid_grid is is currently experimental. It may undergo "
+        "breaking changes in future versions without notice.",
+        FutureWarning,
+    )
     if any(r < 1 for r in refinement):
         raise ValueError(f"Refinement factors must be >= 1, got {refinement}")
 

--- a/src/fmu/tools/nestedhybridgrid/nestedhybrid.py
+++ b/src/fmu/tools/nestedhybridgrid/nestedhybrid.py
@@ -360,7 +360,7 @@ def create_nested_hybrid_grid(
         mother cells to their connected refined cells.
     """
     warnings.warn(
-        "create_nested_hybrid_grid is is currently experimental. It may undergo "
+        "create_nested_hybrid_grid is currently experimental. It may undergo "
         "breaking changes in future versions without notice.",
         FutureWarning,
     )


### PR DESCRIPTION
Since Nested Hybrid Grid is still experimental and the API will change as we experiment on it, we need to flag it so that user understand the risk.

No test as it's only documentation and temporarily printing out a warning.

## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [ ] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
