### PR TITLE
BUG: Updated calculation of new_vertical_axis

### DIFF
--- a/src/fmu/tools/domainconversion/dconvert.py
+++ b/src/fmu/tools/domainconversion/dconvert.py
@@ -593,7 +593,7 @@ class DomainConversion:
         start = rcube.zori
         stop = zmax_actual + rcube.zinc
         num_steps = int((stop - start) / (rcube.zinc - np.finfo(np.float32).eps))
-        new_vertical_axis = np.linspace(start, stop, num_steps)
+        new_vertical_axis = np.linspace(start, zmax_actual, num_steps)
 
         seismic_attribute_result_cube = np.full(rcube.values.shape, undefined)
         # Perform the interpolation for each (x, y) location

--- a/tests/domainconversion/test_domainconversion.py
+++ b/tests/domainconversion/test_domainconversion.py
@@ -294,3 +294,22 @@ def test_domainconvert_cube_outside(
 
     with pytest.raises(ValueError, match="not fully inside the model area."):
         dc.depth_convert_cube(newcube)
+
+
+def test_depth_cube_values(smallcube: xtgeo.Cube) -> None:
+    """Test if depth and time cube values are equal with vconst = 2000 m/s."""
+
+    surface_template = xtgeo.surface_from_cube(smallcube, value=0)
+
+    d0 = surface_template.copy()
+    d0.values = 5
+    d1 = surface_template.copy()
+    d1.values = 100
+
+    dlist = [d0, d1]
+    tlist = dlist  # thus vconst = 2000 m/s; depth equal to time seismic
+    dc = DomainConversion(dlist, tlist)
+
+    new_depth_cube = dc.depth_convert_cube(smallcube, zinc=1.0, zmin=0, zmax=100)
+
+    assert np.allclose(smallcube.values, new_depth_cube.values, atol=0.0001)


### PR DESCRIPTION
Resolves #444

The calculation of new_vertical axis in _domain_convert_cube was wrong and had the np.linspace 'stop' set to a values that was one increment too high. Fixed with the actual zmax_actual.

## Checklist

- [x] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [ ] If not squash merging, every commit passes tests
- [ ] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated  NOT necessary
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch  YES, but there were PRs in other files that came after my rebase
- [ ] Added comments on this PR where appropriate to help reviewers
- [ ] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
