### PR TITLE
BUG: Fix stretch in converted seismic when MSL is given and avoid flo…

### DIFF
--- a/src/fmu/tools/domainconversion/dconvert.py
+++ b/src/fmu/tools/domainconversion/dconvert.py
@@ -245,6 +245,11 @@ class DomainConversion:
             vspeed.values *= 2000
             vel.append(vspeed)
 
+        d1_values = self._d_surfaces[1].values
+        t1_values = self._t_surfaces[1].values
+        if np.allclose(d1_values, 0.0) and np.allclose(t1_values, 0.0):
+            vel[0] = vel[1]
+
         vel.insert(0, vel[0])
         self._v_surfaces = vel
         _logger.debug("Create velocity maps for average velocities from MSL...  DONE")
@@ -266,6 +271,11 @@ class DomainConversion:
             vslow.values = np.divide((t1.values - t0.values), ddiff)
             vslow.values /= 2000
             slow.append(vslow)
+
+        d1_values = self._d_surfaces[1].values
+        t1_values = self._t_surfaces[1].values
+        if np.allclose(d1_values, 0.0) and np.allclose(t1_values, 0.0):
+            slow[0] = slow[1]
 
         slow.insert(0, slow[0])
         self._s_surfaces = slow
@@ -318,23 +328,23 @@ class DomainConversion:
     ) -> tuple[list[xtgeo.RegularSurface], list[xtgeo.RegularSurface]]:
         """Resample surfaces to match the input cube.
 
-        The time and velocity surfaces do already exist, but they are not sampled the
+        The time and depth surfaces do already exist, but they are not sampled the
         actual cube, so we do that here.
         """
         _logger.debug("Resample surfaces to cube")
-        xsurfs = self._t_surfaces if time2depth else self._d_surfaces  # time or depth
-        ssurfs = self._v_surfaces if time2depth else self._s_surfaces  # "speed"
+        xsurfs = self._t_surfaces if time2depth else self._d_surfaces
+        ysurfs = self._d_surfaces if time2depth else self._t_surfaces
 
         incube_template = xtgeo.surface_from_cube(incube, value=0)
 
         x_surfaces = self._resample_check_surfaces(
             xsurfs, incube_template, fill=True, ensure_consistency=True
         )
-        s_surfaces = self._resample_check_surfaces(
-            ssurfs, incube_template, fill=True, ensure_consistency=False
-        )  # intended: do not ensure consistency of velocities
+        y_surfaces = self._resample_check_surfaces(
+            ysurfs, incube_template, fill=True, ensure_consistency=True
+        )
 
-        return x_surfaces, s_surfaces
+        return x_surfaces, y_surfaces
 
     @staticmethod
     def max_depth_for_cube(cube: xtgeo.Cube) -> float:
@@ -350,50 +360,56 @@ class DomainConversion:
         """
 
         _logger.debug("Incube dimensions: %s", incube.values.shape)
+        cube = self._recreate_cube_from_msl(incube, resample=True)
+        _logger.debug("Incube extended to MSL dimensions: %s", cube.values.shape)
 
-        _incube = self._time_cube if time2depth else self._depth_cube
         result_description = "velocity" if time2depth else "slowness"
-        _speed = self._vcube_t if time2depth else self._scube_d
-
-        _incube = self._recreate_cube_from_msl(incube, resample=True)
-
-        _logger.debug("Incube extended to MSL dimensions: %s", _incube.values.shape)
-
         _logger.debug("Create average %s cube", result_description)
-        _speed = _incube.copy()
+        speedcube = cube.copy()
 
-        incube_arr = [
-            _incube.zori + n * _incube.zinc for n in range(_incube.values.shape[2])
-        ]
+        cube_arr = [cube.zori + n * cube.zinc for n in range(cube.values.shape[2])]
 
-        speedcube_values = np.zeros_like(_incube.values)
+        speedcube_values = np.zeros_like(cube.values)
 
-        # resample surfaces to match the input cube
-        x_surfaces, s_surfaces = self._resample_surfaces_to_cube(_incube, time2depth)
+        # Resample surfaces to match the input cube
+        x_surfaces, y_surfaces = self._resample_surfaces_to_cube(cube, time2depth)
 
-        xlen = len(x_surfaces)
-        slen = len(s_surfaces)
-
-        assert xlen == slen
+        if len(x_surfaces) != len(y_surfaces):
+            raise ValueError("x_surfaces and y_surfaces must have the same length")
 
         for i in range(speedcube_values.shape[0]):
             for j in range(speedcube_values.shape[1]):
-                xmap = [x_surfaces[num].values[i, j] for num in range(xlen)]
-                smap = [s_surfaces[num].values[i, j] for num in range(slen)]
+                xmap = [surf.values[i, j] for surf in x_surfaces]
+                ymap = [surf.values[i, j] for surf in y_surfaces]
 
-                speedcube_values[i, j, :] = np.interp(incube_arr, xmap, smap)
+                # Linear interpolation and extrapolation of time-depth function
+                y_arr = np.interp(cube_arr, xmap, ymap)
+                right_slope = (ymap[-1] - ymap[-2]) / (xmap[-1] - xmap[-2])
+                y_arr = np.where(
+                    cube_arr > xmap[-1],
+                    ymap[-1] + right_slope * (cube_arr - xmap[-1]),
+                    y_arr,
+                )
 
-        _speed.values = speedcube_values
+                if time2depth:
+                    speedcube_values[i, j, 1:] = y_arr[1:] / cube_arr[1:] * 2000
+                else:
+                    speedcube_values[i, j, 1:] = y_arr[1:] / cube_arr[1:] / 2000
 
-        # update references
+        # Make sure first sample also gets a non-zero value
+        speedcube_values[:, :, 0] = speedcube_values[:, :, 1]
+
+        speedcube.values = speedcube_values
+
+        # Update references
         if time2depth:
             _logger.debug("Update internal time cube and velocity cube")
-            self._time_cube = _incube
-            self._vcube_t = _speed
+            self._time_cube = cube
+            self._vcube_t = speedcube
         else:
             _logger.debug("Update internal depth cube and slowness cube")
-            self._depth_cube = _incube
-            self._scube_d = _speed
+            self._depth_cube = cube
+            self._scube_d = speedcube
 
     def _derive_result_cube_design(
         self,
@@ -420,10 +436,14 @@ class DomainConversion:
         )
 
         zdiff = zmax_estimated - zmin_estimated
-        zmin_new = zmin_proposed if zmin_proposed else zmin_estimated - zdiff * 0.1
+        zmin_new = (
+            zmin_proposed if zmin_proposed is not None else zmin_estimated - zdiff * 0.1
+        )
         zmin_new = 0.0 if zmin_new < 0.0 else zmin_new
 
-        zmax_new = zmax_proposed if zmax_proposed else zmax_estimated + zdiff * 0.1
+        zmax_new = (
+            zmax_proposed if zmax_proposed is not None else zmax_estimated + zdiff * 0.1
+        )
 
         if not zinc_proposed:
             # e.g. if time2depth:
@@ -447,7 +467,14 @@ class DomainConversion:
         nlay_above = int(zori / zinc_actual)
         # assure that zori is a whole number multiple of zinc_depth starting from 0.0
         zori = nlay_above * zinc_actual
-        nlay = int((zmax_new - zori) / zinc_actual) + 1 + nlay_above
+
+        # avoid floating-point errors
+        n = (zmax_new - zori) / zinc_actual
+        if np.isclose(n, np.rint(n), atol=5e-4):
+            n = int(np.rint(n))
+        else:
+            n = int(np.floor(n))
+        nlay = n + 1 + nlay_above
 
         zmax_new = zori + (nlay - 1) * zinc_actual
 
@@ -460,7 +487,7 @@ class DomainConversion:
 
         # now create the depth cube, but from 0, not zori
         # (to later be cropped with nlay_above)
-        xinv_cube = xtgeo.Cube(
+        cube = xtgeo.Cube(
             xori=incube.xori,
             yori=incube.yori,
             zori=0.0,
@@ -477,9 +504,9 @@ class DomainConversion:
             values=0.0,
         )
         if time2depth:
-            self._depth_cube = xinv_cube
+            self._depth_cube = cube
         else:
-            self._time_cube = xinv_cube
+            self._time_cube = cube
 
         self._nlay_cropper = (nlay_above, 0)
 
@@ -576,7 +603,8 @@ class DomainConversion:
         scube = self._vcube_t if time2depth else self._scube_d
 
         # do the actual depth conversion...
-        assert scube.values.shape == xcube.values.shape
+        if scube.values.shape != xcube.values.shape:
+            raise ValueError("scube and xcube must have the same shape")
 
         delta = xcube.zinc / 2000 if time2depth else xcube.zinc * 2000
         vertical = xcube.copy()  # "vertical" is "times" if time2depth is True

--- a/tests/domainconversion/test_domainconversion.py
+++ b/tests/domainconversion/test_domainconversion.py
@@ -92,6 +92,26 @@ def fixture_smallcube() -> xtgeo.Cube:
     )
 
 
+@pytest.fixture(name="smallsinecube")
+def fixture_smallsinecube() -> xtgeo.Cube:
+    """Fixture for making a small synthetic test cube with sine wave"""
+    cube_values = np.zeros((3, 4, 101))
+    sine_wave = 3.0 * np.sin(0.5 * np.arange(cube_values.shape[2]))
+    cube_values[:, :, :] = sine_wave
+
+    return xtgeo.Cube(
+        ncol=3,
+        nrow=4,
+        nlay=101,
+        xinc=1.0,
+        yinc=1.0,
+        zinc=1.0,
+        values=cube_values,
+        ilines=[3, 6, 9],
+        xlines=[42, 40, 38, 36],
+    )
+
+
 @pytest.fixture(name="simplesurfs")
 def fixture_simple_surfaces(
     smallcube: xtgeo.Cube,
@@ -193,7 +213,7 @@ def test_generate_simple_velocube(
 @pytest.mark.parametrize(
     "input, expected",
     [
-        # [(None, None, None), (1.1, 0, 82.5)],  # TODO: Take a look at this
+        [(None, None, None), (1.1, 0, 82.5)],
         [(1.1, 0.0, 100), (1.1, 0.0, 99.0)],
         [(1.5, 0.0, 100), (1.5, 0.0, 99.0)],
         [(1.5, 20.0, 100), (1.5, 19.5, 99.0)],
@@ -296,13 +316,13 @@ def test_domainconvert_cube_outside(
         dc.depth_convert_cube(newcube)
 
 
-def test_depth_cube_values(smallcube: xtgeo.Cube) -> None:
+def test_depth_cube_values(smallsinecube: xtgeo.Cube) -> None:
     """Test if depth and time cube values are equal with vconst = 2000 m/s."""
 
-    surface_template = xtgeo.surface_from_cube(smallcube, value=0)
+    surface_template = xtgeo.surface_from_cube(smallsinecube, value=0)
 
     d0 = surface_template.copy()
-    d0.values = 5
+    d0.values = 10
     d1 = surface_template.copy()
     d1.values = 100
 
@@ -310,6 +330,27 @@ def test_depth_cube_values(smallcube: xtgeo.Cube) -> None:
     tlist = dlist  # thus vconst = 2000 m/s; depth equal to time seismic
     dc = DomainConversion(dlist, tlist)
 
-    new_depth_cube = dc.depth_convert_cube(smallcube, zinc=1.0, zmin=0, zmax=100)
+    new_depth_cube = dc.depth_convert_cube(smallsinecube, zinc=1.0, zmin=0, zmax=100)
 
-    assert np.allclose(smallcube.values, new_depth_cube.values, atol=0.0001)
+    assert np.allclose(smallsinecube.values, new_depth_cube.values, atol=0.0001)
+
+
+def test_depth_cube_values_with_msl(smallsinecube: xtgeo.Cube) -> None:
+    """With MSL, test if depth and time cube values are equal with vconst = 2000 m/s."""
+
+    surface_template = xtgeo.surface_from_cube(smallsinecube, value=0)
+
+    d0 = surface_template.copy()
+    d0.values = 0
+    d1 = surface_template.copy()
+    d1.values = 10
+    d2 = surface_template.copy()
+    d2.values = 100
+
+    dlist = [d0, d1, d2]
+    tlist = dlist  # thus vconst = 2000 m/s; depth equal to time seismic
+    dc = DomainConversion(dlist, tlist)
+
+    new_depth_cube = dc.depth_convert_cube(smallsinecube, zinc=1.0, zmin=0, zmax=100)
+
+    assert np.allclose(smallsinecube.values, new_depth_cube.values, atol=0.0001)


### PR DESCRIPTION
…ating-point errors

Resolves #445 and #446 

Added several fixes that were related. It became therefore a relatively large pull-request.

1. In the tests, the issue with the commented out line with parameters [(None, None, None), (1.1, 0, 82.5)] for test_proposing_zinc_etc_depthconvert was resolved by adding correct support for None as input in dconvert.py _derive_result_cube_design and by dealing with potential floating-point errors when calculating the nlay parameter.

2. There was a substantial methodological issue with the way the velocity or slowness cubes were generated in dconvert.py _extend_incube_create_speed_cube_average. Originally, the average velocity or slowness maps were interpolated and extrapolated with np.interp to get the upsampled 'speed' function corresponding to the trace sampling. However, this could lead to stretching of the converted seismic in the overburden and wrong velocities below the last horizon. I have now changed the interpolation to linear interpolation of the time-depth function adding linear right-slope extrapolation which resolves the issues. This required also an update of _resample_surfaces_to_cube, a helper function which is only called by _extend_incube_create_speed_cube_average, returning time and depth surfaces instead of time/depth and velocity/slowness surfaces, depending if converting time->depth or vice versa.

3. When providing MSL horizons for time and depth (MSL: everywhere z = 0), one got different results compared to the case they were not provided. The results should have been identical (now included tests for this). The result with the MSL given showed stretched seismic in the overburden. This issue was solved by case differentiation if MSL was input in dconvert.py _velo_maps_average and likewise _slow_maps_average.

The features were related because they failed on the test_depth_cube_values_with_msl and test_depth_cube_values, depending on the input. I have also added a small sine-wave cube for testing, because I think the comparison before-after is more valid when you have data throughout the cube. The cube will also be used in a future PR with respect to amplitude preservation and trace interpolation.

## Checklist

- [x] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [ ] If not squash merging, every commit passes tests
- [ ] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [ ] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
