### PR TITLE
ENH: Added FFT trace interpolation for amplitude preservation

### DIFF
--- a/docs/domain_conversion.rst
+++ b/docs/domain_conversion.rst
@@ -1,14 +1,23 @@
 Domain conversion
 =================
 
-In RMS it is possible to do domain conversion using the menu option, but in
-some cases it convenient to be able to convert domains using a script. This
-module provides a method to convert domains in pure python.
+In RMS, domain conversion can be performed through the right-click menu or
+dedicated jobs. However, in some cases it is convenient to perform domain
+conversion from a script. This module provides pure Python implementations for
+converting cubes and surfaces between the time and depth domains.
 
-The functions are based on that we have matching pairs of surfaces for the two
-domains. The code will then interpolate the data from the source domain to
-the target domain. This will be based on *average* velocity or slowness, in constrast to
-the RMS domain conversion which is based on an *interval* velocity model.
+The functions are based on matching pairs of surfaces in the time and depth
+domains. Data is interpolated from the source domain to the target domain using
+*average* velocity or slowness. This differs from the RMS domain conversion,
+which uses an *interval* velocity model.
+
+For domain conversion of cubes, two trace interpolation methods are available:
+
+- **linear**: Quick, but not fully amplitude preserving. The degree of
+  amplitude loss depends on the sampling interval and frequency content. This
+  is currently the default method.  
+- **fft**: Amplitude preserving, but computationally more expensive. This
+  method is planned to become the default in a future release.
 
 Examples
 --------
@@ -16,7 +25,7 @@ Examples
 Example 1
 ^^^^^^^^^
 
-Depth convert a cube from time to depth domain.
+Convert a cube from the time domain to the depth domain.
 
 .. code-block:: python
 
@@ -32,8 +41,8 @@ Depth convert a cube from time to depth domain.
 
     dc = DomainConversion([depth1, depth2], [time1, time2])
 
-    # now depth convert cube
-    cube_in_depth = dc.depth_convert_cube(cube, zinc=2)
+    # now depth convert cube with fft method
+    cube_in_depth = dc.depth_convert_cube(cube, zinc=2, method="fft")
 
     cube_in_depth.to_file("path/to/output/cube_in_depth.segy")
 
@@ -41,7 +50,7 @@ Depth convert a cube from time to depth domain.
 Example 2
 ^^^^^^^^^
 
-Time convert a cube and a surface from depth to time domain.
+Convert a cube and a surface from the depth domain to the time domain.
 
 .. code-block:: python
 
@@ -64,14 +73,14 @@ Time convert a cube and a surface from depth to time domain.
 
     dc = DomainConversion(dlist, tlist)
 
-    time_cube = dc.time_convert_cube(cube, tinc=4)
+    time_cube = dc.time_convert_cube(cube, tinc=4, method="fft")
 
     time_other_aslist = dc.time_convert_surfaces([depth_other])
 
 Example 3
 ^^^^^^^^^
 
-A larger example with cubes and surfaces in RMS python environment.
+A larger example using cubes and surfaces in an RMS Python environment.
 
 .. code-block:: python
 
@@ -93,17 +102,18 @@ A larger example with cubes and surfaces in RMS python environment.
     TINC = 3
     MINTIME = 1500
     MAXTIME = 1900
+    METHOD = "fft"
 
     CLIP_CATALOG = "testing_dconv"
     PRJ = project
-    
+
 
     def load_input():
         """Load input data, such as cubes and surfaces."""
         amplcube = xtgeo.cube_from_roxar(PRJ, AMPL_TIME_CUBE)
         aicube = xtgeo.cube_from_roxar(PRJ, AI_TIME_CUBE)
         print(f"Loading cubes {AMPL_TIME_CUBE} and {AI_TIME_CUBE}... DONE")
-    
+
         depthsurfs = []
         timesurfs = []
         for ds in HORIZONS:
@@ -114,46 +124,46 @@ A larger example with cubes and surfaces in RMS python environment.
         for surf in HORIZONS:
             tsfr = xtgeo.surface_from_roxar(PRJ, surf, TIME_CATEGORY_OTHER)
             othertimesurfs.append(tsfr)
-    
+
         print("Loading surfaces... DONE")
         return amplcube, aicube, depthsurfs, timesurfs, othertimesurfs
-    
-    
+
+
     def create_domain_conversion_model(dsurfs, tsurfs):
         """Create a domain model from matching depth and time surfaces."""
         print("Create domain conversion (velocity/slowness) model...")
         dc = DomainConversion(depth_surfaces=dsurfs, time_surfaces=tsurfs)
         print("Create domain conversion model... DONE")
         return dc
-    
-    
+
+
     def _depth_convert_cube(dc, mycube):
-        """Depht convert a cube (generic)."""
+        """Depth convert a cube (generic)."""
         print("Depth convert cube...")
-        dcube = dc.depth_convert_cube(mycube, zinc=ZINC, zmin=MINDEPTH, zmax=MAXDEPTH)
+        dcube = dc.depth_convert_cube(mycube, zinc=ZINC, zmin=MINDEPTH, zmax=MAXDEPTH, method=METHOD)
         print("Depth convert cube... DONE")
         return dcube
-    
-    
+
+
     def _time_convert_cube(dc, dcube):
         """Time convert a cube using the slowness model (generic)."""
         print("Time convert cube...")
-        tcube = dc.time_convert_cube(dcube, tinc=TINC, tmin=MINTIME, tmax=MAXTIME)
+        tcube = dc.time_convert_cube(dcube, tinc=TINC, tmin=MINTIME, tmax=MAXTIME, method=METHOD)
         print("Time convert cube... DONE")
         return tcube
-    
-    
+
+
     def domain_convert_some_cube(dc, tcube, nickname="something"):
-        """Back and forth with some cube (here AI); demonstrate the conv. of cubes."""
+        """Convert a cube to depth and back again for demonstration."""
         dcube = _depth_convert_cube(dc, tcube)
         tcube_again = _time_convert_cube(dc, dcube)  # going back again, for demonstration
         dcube.to_roxar(PRJ, nickname + "_depth")
         tcube_again.to_roxar(PRJ, nickname + "_time_again")
         print(f"Save cubes in RMS... ({nickname}...) DONE")
-    
-    
+
+
     def domain_convert_surfaces(dc, othertimesurfs):
-        """Use domain model to depth and time convert some other surfaces."""
+        """Convert surfaces between time and depth domains."""
         print("Depth and time convert surfaces...")
         depthsurfaces = dc.depth_convert_surfaces(othertimesurfs)
         # store on clipboard
@@ -165,18 +175,18 @@ A larger example with cubes and surfaces in RMS python environment.
         for ts, name in zip(new_timesurfaces, HORIZONS):
             ts.to_roxar(PRJ, f"{name}_time", CLIP_CATALOG, stype="clipboard")
         print("Depth and time convert surfaces... DONE")
-    
-    
+
+
     # entry point for script
     if __name__ == "__main__":
         ampl, ai, ds, ts, other = load_input()
         dc = create_domain_conversion_model(ds, ts)
-    
+
         for nickname, cube in zip(["ampl_test", "ai_test"], [ampl, ai]):
             domain_convert_some_cube(dc, cube, nickname)
         domain_convert_surfaces(dc, other)
-    
+
         print("Done")
-    
-    
-    
+
+
+

--- a/src/fmu/tools/domainconversion/dconvert.py
+++ b/src/fmu/tools/domainconversion/dconvert.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
 import logging
+import os
+import warnings
 from dataclasses import dataclass, field
-from typing import Generator
+from typing import Generator, Literal
 
 import numpy as np
 import xtgeo
+from scipy.fft import irfft, next_fast_len, rfft
 
 _logger = logging.getLogger(__name__)
 
@@ -695,6 +698,7 @@ class DomainConversion:
         zmax_proposed: float | None = None,
         undefined: float = -999.25,
         time2depth: bool = True,
+        method: Literal["fft", "linear"] = "linear",
     ) -> xtgeo.Cube:
         """Generic domain conversion of a cube.
 
@@ -721,15 +725,19 @@ class DomainConversion:
 
         delta = xcube.zinc / 2000 if time2depth else xcube.zinc * 2000
         vertical = xcube.copy()  # "vertical" is "times" if time2depth is True
-        varr = [0 + n * delta for n in range(xcube.values.shape[2])]
-        vertical.values[:, :, :] = varr
+        n = xcube.values.shape[2]
+        vertical.values[:, :, :] = np.arange(n, dtype=vertical.values.dtype) * delta
         result_values = scube.values * vertical.values
 
         rcube = self._depth_cube if time2depth else self._time_cube
 
         zmax_actual = self.max_depth_for_cube(rcube)
 
-        _logger.debug("Zmax for depth cube is %s", zmax_actual)
+        _logger.debug(
+            "Zmax for domain converted cube is %s (time2depth: %s)",
+            zmax_actual,
+            time2depth,
+        )
 
         start = rcube.zori
         stop = zmax_actual + rcube.zinc
@@ -737,17 +745,129 @@ class DomainConversion:
         new_vertical_axis = np.linspace(start, zmax_actual, num_steps)
 
         seismic_attribute_result_cube = np.full(rcube.values.shape, undefined)
-        # Perform the interpolation for each (x, y) location
-        for i in range(xcube.values.shape[0]):
-            for j in range(xcube.values.shape[1]):
-                result_trace = result_values[i, j, :]
-                seismic_trace = xcube.values[i, j, :]
 
-                seismic_attribute_result_cube[i, j, :] = np.interp(
-                    new_vertical_axis,
-                    result_trace,
-                    seismic_trace,
-                )
+        # Local function
+        def _fft_resample_block(traces_block, m, workers):
+            """Resample block of traces with FFT."""
+            B, n0 = traces_block.shape
+            X = rfft(traces_block, axis=1, workers=workers)
+            Y = irfft(X, n=m, axis=1, workers=workers)
+            Y *= m / n0  # Amplitude scaling
+            return Y.astype(np.float32, copy=False)
+
+        _logger.info(
+            "Resampling traces with method '%s' (time2depth: %s)...",
+            method,
+            time2depth,
+        )
+
+        if method == "fft":
+            # Resample traces with FFT followed by linear interpolation
+            # preserves amplitudes. Optimized with processing of blocks of
+            # traces and workers for parallel computation.
+
+            # Increment 1.0 (ms or m) is good for normal seismic frequencies
+            # with negligable amplitude loss.
+            zinc_fine_target = min(1.0, xcube.zinc / 2)
+
+            # Block_size is the number of traces processed in batch.
+            # Tested on linux server with 42 MB cache and 4 workers.
+            block_size = 512
+
+            # If running on the lsf cluster, use the number of CPUs allocated
+            ncpu_env = os.environ.get("OMP_NUM_THREADS")
+            if ncpu_env:
+                workers = int(ncpu_env)
+            else:
+                # If running locally use half of available CPUs
+                ncpu = os.cpu_count()
+                workers = max(1, ncpu // 2) if ncpu else 1
+
+            vert_trace = np.arange(n) * xcube.zinc
+            trace_length = n * xcube.zinc
+
+            # Choose m with next_fast_len to optimize speed
+            m = next_fast_len(int(np.round(trace_length / zinc_fine_target)))
+            zinc_fine = trace_length / m
+            vert_trace_fine = np.arange(m) * zinc_fine
+
+            n_traces = xcube.ncol * xcube.nrow
+            seismic_traces = xcube.values.reshape(n_traces, n)
+            result_traces = result_values.reshape(n_traces, n)
+
+            k = new_vertical_axis.size
+            result_trace_fine = np.empty(k, dtype=np.float32)
+            out_traces = seismic_attribute_result_cube.reshape(n_traces, k)
+
+            _logger.info(
+                "FFT resampling with a block size of %s traces using %s workers",
+                block_size,
+                workers,
+            )
+            _logger.info(
+                "FFT resampling from %s samples (zinc=%s) to %s samples (zinc=%.4f)",
+                n,
+                xcube.zinc,
+                m,
+                zinc_fine,
+            )
+            _logger.info(
+                "Linear interpolation to new vertical axis with %s samples (zinc=%s)",
+                new_vertical_axis.size,
+                rcube.zinc,
+            )
+
+            for start in range(0, n_traces, block_size):
+                # Batched FFT resample
+                stop = min(start + block_size, n_traces)
+                block = seismic_traces[start:stop, :].astype(np.float32, copy=False)
+                block_fine = _fft_resample_block(block, m, workers=workers)
+
+                for b in range(block_fine.shape[0]):
+                    seismic_trace_fine = block_fine[b]
+                    result_trace = result_traces[start + b].astype(
+                        np.float32, copy=False
+                    )
+
+                    # Compute z-axis of resampled trace
+                    result_trace_fine = np.interp(
+                        vert_trace_fine, vert_trace, result_trace
+                    )
+
+                    # Extrapolate right end linearly in time-depth domain
+                    right_slope = (result_trace[-1] - result_trace[-2]) / xcube.zinc
+                    result_trace_fine = np.where(
+                        vert_trace_fine > vert_trace[-1],
+                        result_trace[-1]
+                        + right_slope * (vert_trace_fine - vert_trace[-1]),
+                        result_trace_fine,
+                    )
+
+                    # Linear interpolate fine trace to new vertical axis
+                    out_traces[start + b] = np.interp(
+                        new_vertical_axis, result_trace_fine, seismic_trace_fine
+                    )
+                    # Note out_traces is a view of seismic_attribute_result_cube,
+                    # thus the latter is updated.
+
+        elif method == "linear":
+            # Linear interpolation is fast, but does not preserve amplitudes.
+            # Perform the interpolation for each (x, y) location
+            for i in range(xcube.values.shape[0]):
+                for j in range(xcube.values.shape[1]):
+                    result_trace = result_values[i, j, :]
+                    seismic_trace = xcube.values[i, j, :]
+
+                    seismic_attribute_result_cube[i, j, :] = np.interp(
+                        new_vertical_axis,
+                        result_trace,
+                        seismic_trace,
+                    )
+
+        else:
+            raise ValueError(
+                "The trace interpolation method must be either 'linear' or 'fft'."
+            )
 
         if np.isnan(seismic_attribute_result_cube.sum()):
             _logger.warning(
@@ -825,6 +945,7 @@ class DomainConversion:
         zmin: float | None = None,
         zmax: float | None = None,
         undefined: float = -999.25,
+        method: Literal["fft", "linear"] = "linear",
     ) -> xtgeo.Cube:
         """Depth convert a cube (time to depth).
 
@@ -834,6 +955,7 @@ class DomainConversion:
             zmin: Proposed z minimum for the output cube.
             zmax: Proposed z maximum for the output cube.
             undefined: Value to use for undefined values in the output cube.
+            method: Trace interpolation method. Must be either 'linear' or 'fft'.
 
         Note:
             The proposed zinc, zmin, zmax are optional and will be calculated from the
@@ -842,6 +964,14 @@ class DomainConversion:
             for technical reasons.
 
         """
+        warnings.warn(
+            "Default trace interpolation method will be set to 'fft' in the near "
+            "future. Explicitely set method='linear' to keep the same results: "
+            "vm.depth_convert_cube(incube, zinc, zmin, zmax, method='linear').",
+            category=FutureWarning,
+            stacklevel=2,
+        )
+
         return self._domain_convert_cube(
             incube,
             zinc_proposed=zinc,
@@ -849,6 +979,7 @@ class DomainConversion:
             zmax_proposed=zmax,
             undefined=undefined,
             time2depth=True,
+            method=method,
         )
 
     def time_convert_cube(
@@ -858,6 +989,7 @@ class DomainConversion:
         tmin: float | None = None,
         tmax: float | None = None,
         undefined: float = -999.25,
+        method: Literal["fft", "linear"] = "linear",
     ) -> xtgeo.Cube:
         """Time convert a cube (depth to time).
 
@@ -867,13 +999,23 @@ class DomainConversion:
             tmin: Proposed time minimum for the output cube.
             tmax: Proposed time maximum for the output cube.
             undefined: Value to use for undefined values in the output cube.
+            method: Trace interpolation method. Must be either 'linear' or 'fft'.
 
         Note:
             The proposed tinc, tmin, tmax are optional and will be calculated from the
             existing input surfaces (making the velocity/slowness model) if not
             provided. If given, the values may be adjusted for technical
             reasons.
+
         """
+        warnings.warn(
+            "Default trace interpolation method will be set to 'fft' in the near "
+            "future. Explicitely set method='linear' to keep the same results: "
+            "vm.time_convert_cube(incube, tinc, tmin, tmax, method='linear').",
+            category=FutureWarning,
+            stacklevel=2,
+        )
+
         return self._domain_convert_cube(
             incube,
             zinc_proposed=tinc,
@@ -881,4 +1023,5 @@ class DomainConversion:
             zmax_proposed=tmax,
             undefined=undefined,
             time2depth=False,
+            method=method,
         )

--- a/tests/domainconversion/test_domainconversion.py
+++ b/tests/domainconversion/test_domainconversion.py
@@ -289,13 +289,17 @@ def test_domainconvert_back_and_forth(
 
     dc = DomainConversion(dlist, tlist)
 
-    new_depth_cube = dc.depth_convert_cube(smallcube, zinc=1, zmax=100, zmin=0)
+    new_depth_cube = dc.depth_convert_cube(
+        smallcube, zinc=1, zmax=100, zmin=0, method="linear"
+    )
     plot_section(smallcube, simplesurfs, title="Input cube in time domain")
 
     plot_section(new_depth_cube, simplesurfs, title="Depth converted cube")
 
     # now timeconvert the newcube
-    new_time_cube = dc.time_convert_cube(new_depth_cube, tinc=1, tmax=100, tmin=0)
+    new_time_cube = dc.time_convert_cube(
+        new_depth_cube, tinc=1, tmax=100, tmin=0, method="linear"
+    )
     plot_section(new_time_cube, simplesurfs, title="Time domain output after d2t")
 
     assert abs((smallcube.values - new_time_cube.values).mean()) < 0.01
@@ -541,3 +545,84 @@ def test_speedcube_with_input_msl_and_default_zinc() -> None:
 
     assert np.isclose(result.zinc, 1.0)
     assert np.isclose(dc.average_velocity_cube_in_time.values[0, 0, 0], 2000.0)
+
+
+def test_trace_interpolation_methods(smallsinecube: xtgeo.Cube) -> None:
+    """Test trace interpolation with 'linear' and 'fft' methods."""
+
+    def downsample_cube(cube, shifted=False):
+        """Downsample cube by a factor of 2.
+
+        shifted : False means start from first sample, True from second
+        """
+        if shifted:
+            start, end = 1, None
+        else:
+            start, end = 0, -1
+
+        return xtgeo.Cube(
+            zori=cube.zori + shifted * cube.zinc,
+            ncol=cube.ncol,
+            nrow=cube.nrow,
+            nlay=cube.nlay // 2,
+            xinc=cube.xinc,
+            yinc=cube.yinc,
+            zinc=cube.zinc * 2,
+            values=cube.values[:, :, start:end:2],
+            ilines=cube.ilines,
+            xlines=cube.xlines,
+        )
+
+    # Tapering for FFT
+    hann_window = np.hanning(smallsinecube.nlay)
+    smallsinecube.values *= hann_window
+
+    smallsinecube_coarse = downsample_cube(smallsinecube)
+    smallsinecube_coarse_shifted = downsample_cube(smallsinecube, shifted=True)
+
+    surface_template = xtgeo.surface_from_cube(smallsinecube_coarse, value=0)
+
+    d0 = surface_template.copy()
+    d0.values = 10
+    d1 = surface_template.copy()
+    d1.values = 100
+
+    dlist = [d0, d1]
+    tlist = dlist  # thus vconst = 2000 m/s; depth equal to time seismic
+    dc = DomainConversion(dlist, tlist)
+
+    for method in ["linear", "fft"]:
+        new_depth_cube = dc.depth_convert_cube(
+            smallsinecube_coarse,
+            zinc=1.0,
+            zmin=0,
+            zmax=100,
+            method=method,
+        )
+        new_depth_cube_coarse = downsample_cube(new_depth_cube)
+        new_depth_cube_coarse_shifted = downsample_cube(new_depth_cube, shifted=True)
+
+        if method == "linear":
+            assert np.allclose(smallsinecube.values, new_depth_cube.values, atol=0.37)
+            assert np.allclose(
+                smallsinecube_coarse.values, new_depth_cube_coarse.values, atol=5.6e-6
+            )
+            assert np.allclose(
+                smallsinecube_coarse_shifted.values,
+                new_depth_cube_coarse_shifted.values,
+                atol=0.37,
+            )
+        elif method == "fft":
+            assert np.allclose(smallsinecube.values, new_depth_cube.values, atol=2.3e-3)
+            assert np.allclose(
+                smallsinecube_coarse.values, new_depth_cube_coarse.values, atol=6.7e-6
+            )
+            assert np.allclose(
+                smallsinecube_coarse_shifted.values,
+                new_depth_cube_coarse_shifted.values,
+                atol=1.8e-4,
+            )
+        else:
+            raise ValueError(
+                "The trace interpolation method must be either 'linear' or 'fft'."
+            )


### PR DESCRIPTION
Resolves #447 

Added FFT method for trace interpolation to achieve amplitude preservation. 

The 'linear' method with np.interp, that was in the code before, is fast but does not preserve amplitudes. The degree of amplitude loss depends on sampling interval and frequency content of the input. The amplitude loss is particularly visible when running a round trip time->depth->time. 

A new input argument 'method' has been added and the new 'fft' method is set as default. The 'linear' method is kept as alternative that could be used when speed is  more important than accuracy.

## Checklist

- [x] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [ ] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [ ] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
