### PR TITLE
TST: Add tests for _same_cube_geometry

### DIFF
--- a/tests/domainconversion/test_domainconversion.py
+++ b/tests/domainconversion/test_domainconversion.py
@@ -375,3 +375,65 @@ def test_reuse_speedcube(
     expected = "Reuse velocity cube for time->depth conversion"
 
     assert (module, logging.DEBUG, expected) in caplog.record_tuples
+
+
+def test_same_cube_geometry(
+    simplesurfs: tuple[list[xtgeo.RegularSurface], list[xtgeo.RegularSurface]],
+) -> None:
+    """Compare cubes with different geometries."""
+
+    cube1 = xtgeo.Cube(
+        ncol=3,
+        nrow=4,
+        nlay=100,
+        xinc=1.0,
+        yinc=1.0,
+        zinc=1.0,
+    )
+
+    cube2 = xtgeo.Cube(
+        ncol=2,
+        nrow=4,
+        nlay=101,
+        xinc=1.0,
+        yinc=1.0,
+        zinc=1.0,
+    )
+
+    cube3 = xtgeo.Cube(
+        ncol=3,
+        nrow=4,
+        nlay=100,
+        xinc=1.0,
+        yinc=1.0,
+        zinc=1.0,
+        yflip=-1,
+    )
+
+    cube4 = xtgeo.Cube(
+        xori=10,
+        ncol=3,
+        nrow=4,
+        nlay=100,
+        xinc=1.0,
+        yinc=1.0,
+        zinc=1.0,
+    )
+
+    dlist = [xtgeo.surface_from_cube(cube1, value=50)]
+    dc = DomainConversion(depth_surfaces=dlist, time_surfaces=dlist)
+
+    # Same cubes
+    assert dc._same_cube_geometry(cube1, cube1)
+
+    # cube2 has different geometry than surfaces to build dc object
+    assert dc._same_cube_geometry(cube2, cube2)
+
+    # Cubes have different dimensions
+    assert not dc._same_cube_geometry(cube1, cube2)
+
+    # Cubes have different attributes, high atol (here: yflip)
+    assert not dc._same_cube_geometry(cube1, cube3)
+
+    # Cubes have different attributes, low atol (here: xori)
+    assert not dc._same_cube_geometry(cube1, cube4)


### PR DESCRIPTION
Resolves #451 

Added test for _same_cube_geometry method with 4 cases.
Kept `_same_cube_geometry` as staticmethod as setup of DomainConversion is just two lines of code.

## Checklist

- [x] Tests added (this adds additional tests to a previous commit)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [ ] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [ ] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
