### PR TITLE
ENH: Efficient inter- and extrapolation of speedcube

### DIFF
--- a/src/fmu/tools/domainconversion/dconvert.py
+++ b/src/fmu/tools/domainconversion/dconvert.py
@@ -430,9 +430,12 @@ class DomainConversion:
         _logger.debug("Create average %s cube", result_description)
         speedcube = cube.copy()
 
-        cube_arr = [cube.zori + n * cube.zinc for n in range(cube.values.shape[2])]
-
-        speedcube_values = np.zeros_like(cube.values)
+        # Use float32 where possible to increase speed
+        ni, nj, n = cube.values.shape
+        z0 = np.float32(cube.zori)
+        zinc = np.float32(cube.zinc)
+        cube_arr = z0 + zinc * np.arange(n, dtype=np.float32)
+        speedcube_values = np.zeros_like(cube.values, dtype=np.float32)
 
         # Resample surfaces to match the input cube
         x_surfaces, y_surfaces = self._resample_surfaces_to_cube(cube, time2depth)
@@ -440,24 +443,71 @@ class DomainConversion:
         if len(x_surfaces) != len(y_surfaces):
             raise ValueError("x_surfaces and y_surfaces must have the same length")
 
-        for i in range(speedcube_values.shape[0]):
-            for j in range(speedcube_values.shape[1]):
-                xmap = [surf.values[i, j] for surf in x_surfaces]
-                ymap = [surf.values[i, j] for surf in y_surfaces]
+        # Stack horizon maps into arrays: X is the 'xmap' (e.g. time) and Y
+        # is 'ymap' (e.g. depth). X and Y have shape (H, ni, nj).
+        X = np.stack([s.values for s in x_surfaces]).astype(np.float32, copy=False)
+        Y = np.stack([s.values for s in y_surfaces]).astype(np.float32, copy=False)
+        H = X.shape[0]
 
-                # Linear interpolation and extrapolation of time-depth function
-                y_arr = np.interp(cube_arr, xmap, ymap)
-                right_slope = (ymap[-1] - ymap[-2]) / (xmap[-1] - xmap[-2])
-                y_arr = np.where(
-                    cube_arr > xmap[-1],
-                    ymap[-1] + right_slope * (cube_arr - xmap[-1]),
-                    y_arr,
-                )
+        # Slope in first interval where the top is MSL which is 0 everywhere
+        X1, Y1 = X[1], Y[1]
+        S0 = np.divide(Y1, X1, out=np.zeros_like(Y1), where=(X1 != 0))
 
-                if time2depth:
-                    speedcube_values[i, j, 1:] = y_arr[1:] / cube_arr[1:] * 2000
-                else:
-                    speedcube_values[i, j, 1:] = y_arr[1:] / cube_arr[1:] / 2000
+        # Per-interval slopes S[h] between horizons h and h+1
+        dX = X[1:] - X[:-1]
+        dY = Y[1:] - Y[:-1]
+        S = np.divide(dY, dX, out=np.zeros_like(dY), where=dX != 0)
+        S_last = S[-1]  # Slope for right-end extrapolation
+
+        # Convenience views that align with interval indices h in 0..H-2
+        X0_all = X[:-1]
+        Y0_all = Y[:-1]
+
+        # Work buffer for the current 2D slice
+        y2d = np.empty((ni, nj), dtype=np.float32)
+
+        # Fast assigment of constant speed between first and second horizon.
+        # Compute shallowest second surface sample index globally
+        k1_min = int(
+            np.clip(np.searchsorted(cube_arr, np.nanmin(X1), side="left"), 1, n)
+        )
+
+        if time2depth:
+            speedcube_values[:, :, :k1_min] = S0[:, :, None] * 2000.0
+        else:
+            speedcube_values[:, :, :k1_min] = S0[:, :, None] / 2000.0
+
+        # Loop for k >= k1_min treating deeper layers and right-side extrapolation
+        for k in range(k1_min, n):
+            x0 = cube_arr[k]
+
+            # Find interval index h: X[h] <= x0 < X[h+1]
+            h_idx = (x0 >= X).sum(axis=0) - 1  # (ni, nj), can be -1..H-1
+            h_clip = h_idx.clip(0, H - 2)  # (ni, nj), clipped to 0..H-2
+
+            # Gather X[h], Y[h], S[h] for each (i, j)
+            sel = h_clip[None, ...]  # Shape (1, ni, nj) for take_along_axis
+            Xh = np.take_along_axis(X0_all, sel, axis=0)[0]
+            Yh = np.take_along_axis(Y0_all, sel, axis=0)[0]
+            Sh = np.take_along_axis(S, sel, axis=0)[0]
+
+            # Linear interpolation inside [X[h], X[h+1]] interval
+            np.subtract(x0, Xh, out=y2d)
+            np.multiply(Sh, y2d, out=y2d)
+            np.add(y2d, Yh, out=y2d)
+
+            # Right side (x0 > X[-1]): linear extrapolation using last slope
+            mask_right = x0 > X[-1]
+            if mask_right.any():
+                yh_last = Y[-1][mask_right]
+                xh_last = X[-1][mask_right]
+                sl_last = S_last[mask_right]
+                y2d[mask_right] = yh_last + sl_last * (x0 - xh_last)
+
+            if time2depth:
+                speedcube_values[:, :, k] = (y2d / x0) * 2000.0
+            else:
+                speedcube_values[:, :, k] = (y2d / x0) / 2000.0
 
         # Make sure first sample also gets a non-zero value
         speedcube_values[:, :, 0] = speedcube_values[:, :, 1]

--- a/tests/domainconversion/test_domainconversion.py
+++ b/tests/domainconversion/test_domainconversion.py
@@ -490,3 +490,54 @@ def test_interval_velocity_maps_with_msl(smallcube: xtgeo.Cube) -> None:
     assert np.ma.allclose(vint_maps[1].values, 2000.0)
     assert np.ma.allclose(vint_maps[2].values, 2000.0)
     assert np.ma.allclose(vint_maps[3].values, 3000.0)
+
+
+def test_speedcube_interpolation(smallcube: xtgeo.Cube) -> None:
+    """Check that speedcube inter- and extrapolation is correct."""
+
+    surface_template = xtgeo.surface_from_cube(smallcube, value=0)
+
+    # Input surfaces in between cube zmin and zmax, thus extrapolation required
+    d0 = surface_template.copy()
+    d0.values = 10
+    d1 = surface_template.copy()
+    d1.values = 50
+
+    dlist = [d0, d1]
+    tlist = dlist  # thus v = 2000 m/s everywhere
+    dc = DomainConversion(dlist, tlist)
+
+    # Domain convert forward and backward to populate dc._vcube_t and dc._scube_d
+    new_depth_cube = dc.depth_convert_cube(smallcube, zinc=1.0, zmin=0, zmax=100)
+    _ = dc.time_convert_cube(new_depth_cube, tinc=1.0, tmin=0, tmax=100)
+
+    velocity_trace = dc._vcube_t.values[0, 0, :]
+    slowness_trace = dc._scube_d.values[0, 0, :]
+
+    assert np.allclose(velocity_trace, 2000.0)
+    assert np.allclose(slowness_trace, 1 / 2000.0)
+
+
+def test_speedcube_with_input_msl_and_default_zinc() -> None:
+    """Check zinc and topmost sample of velocity cube if msl is given."""
+    cube = xtgeo.Cube(
+        ncol=1,
+        nrow=1,
+        nlay=2,
+        xinc=1.0,
+        yinc=1.0,
+        zinc=1.0,
+        values=np.zeros((1, 1, 2)),
+    )
+    surface_template = xtgeo.surface_from_cube(cube, value=0)
+
+    d0 = surface_template.copy()
+    d0.values = 0.0
+    d1 = surface_template.copy()
+    d1.values = 10.0
+
+    dc = DomainConversion([d0, d1], [d0, d1])
+    result = dc.depth_convert_cube(cube, zmin=0, zmax=10)  # zinc omitted on purpose
+
+    assert np.isclose(result.zinc, 1.0)
+    assert np.isclose(dc.average_velocity_cube_in_time.values[0, 0, 0], 2000.0)


### PR DESCRIPTION
Resolves #446 issue #2 within

Changed from two loops to loop over each trace, which could be up to a million, to one loop over depth indices, which is typically only a few hundreds at most. The speed down to the shallowest point on the first surface below MSL is assigned in one step as it is constant.

These improvements reduce the time needed for interpolation of the speedcube enormously.

## Checklist

- [x] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [ ] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [ ] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
