### PR TITLE
ENH: Add calculation of interval velocity maps

### DIFF
--- a/src/fmu/tools/domainconversion/dconvert.py
+++ b/src/fmu/tools/domainconversion/dconvert.py
@@ -60,6 +60,7 @@ class DomainConversion:
     _scube_d: xtgeo.Cube = field(default=None, init=False)  # avg slowness cube in depth
 
     _v_surfaces: list[xtgeo.RegularSurface] = field(default_factory=list, init=False)
+    _vi_surfaces: list[xtgeo.RegularSurface] = field(default_factory=list, init=False)
     _s_surfaces: list[xtgeo.RegularSurface] = field(default_factory=list, init=False)
     _d_surfaces: list[xtgeo.RegularSurface] = field(default_factory=list, init=False)
     _t_surfaces: list[xtgeo.RegularSurface] = field(default_factory=list, init=False)
@@ -121,6 +122,7 @@ class DomainConversion:
             self.time_surfaces, template_surf, fill=True, ensure_consistency=True
         )
         self._ensure_surfaces_has_msl()
+        self._calculate_interval_velocity_surfaces()
         _logger.debug("Check and fix surfaces... DONE")
 
     @staticmethod
@@ -226,6 +228,32 @@ class DomainConversion:
         self._t_surfaces.insert(0, msl)
         if self._names[0] != "__MSL":
             self._names.insert(0, "__MSL")
+
+    def _calculate_interval_velocity_surfaces(self) -> None:
+        """Calculate interval velocity surfaces."""
+        _logger.debug("Calculate interval velocity surfaces")
+
+        vel = []
+        for no in range(1, len(self._d_surfaces)):
+            t0 = self._t_surfaces[no - 1]
+            t1 = self._t_surfaces[no]
+            d0 = self._d_surfaces[no - 1]
+            d1 = self._d_surfaces[no]
+
+            vint = d1.copy()
+            tdiff = t1.values - t0.values
+            tdiff = np.where(tdiff == 0.0, 1e-06, tdiff)
+            vint.values = np.divide((d1.values - d0.values), tdiff)
+            vint.values *= 2000
+            vel.append(vint)
+
+        d1_values = self._d_surfaces[1].values
+        t1_values = self._t_surfaces[1].values
+        if np.allclose(d1_values, 0.0) and np.allclose(t1_values, 0.0):
+            vel[0] = vel[1]
+
+        vel.insert(0, vel[0])
+        self._vi_surfaces = vel
 
     def _velo_maps_average(self) -> None:
         """Create average velocities from MSL to surface N"""
@@ -704,6 +732,11 @@ class DomainConversion:
     def slowness_surfaces(self) -> Generator[xtgeo.RegularSurface]:
         """Return a generator of slowness surfaces."""
         for surf in self._s_surfaces:
+            yield surf
+
+    def vint_surfaces(self) -> Generator[xtgeo.RegularSurface]:
+        """Return a generator of interval velocity surfaces."""
+        for surf in self._vi_surfaces:
             yield surf
 
     @property

--- a/tests/domainconversion/test_domainconversion.py
+++ b/tests/domainconversion/test_domainconversion.py
@@ -437,3 +437,56 @@ def test_same_cube_geometry(
 
     # Cubes have different attributes, low atol (here: xori)
     assert not dc._same_cube_geometry(cube1, cube4)
+
+
+def test_interval_velocity_maps(smallcube: xtgeo.Cube) -> None:
+    """Check values of interval velocity maps."""
+
+    surface_template = xtgeo.surface_from_cube(smallcube, value=0)
+
+    d0 = surface_template.copy()
+    d0.values = 20
+    d1 = surface_template.copy()
+    d1.values = 65
+    t0 = surface_template.copy()
+    t0.values = 20
+    t1 = surface_template.copy()
+    t1.values = 50
+
+    dlist = [d0, d1]
+    tlist = [t0, t1]
+    dc = DomainConversion(dlist, tlist)
+
+    vint_maps = [vi for vi in dc.vint_surfaces()]
+    assert np.ma.allclose(vint_maps[0].values, 2000.0)
+    assert np.ma.allclose(vint_maps[1].values, 2000.0)
+    assert np.ma.allclose(vint_maps[2].values, 3000.0)
+
+
+def test_interval_velocity_maps_with_msl(smallcube: xtgeo.Cube) -> None:
+    """Check values of interval velocity maps if MSL is input."""
+
+    surface_template = xtgeo.surface_from_cube(smallcube, value=0)
+
+    d0 = surface_template.copy()
+    d0.values = 0
+    d1 = surface_template.copy()
+    d1.values = 20
+    d2 = surface_template.copy()
+    d2.values = 65
+    t0 = surface_template.copy()
+    t0.values = 0
+    t1 = surface_template.copy()
+    t1.values = 20
+    t2 = surface_template.copy()
+    t2.values = 50
+
+    dlist = [d0, d1, d2]
+    tlist = [t0, t1, t2]
+    dc = DomainConversion(dlist, tlist)
+
+    vint_maps = [vi for vi in dc.vint_surfaces()]
+    assert np.ma.allclose(vint_maps[0].values, 2000.0)
+    assert np.ma.allclose(vint_maps[1].values, 2000.0)
+    assert np.ma.allclose(vint_maps[2].values, 2000.0)
+    assert np.ma.allclose(vint_maps[3].values, 3000.0)


### PR DESCRIPTION
Resolves #456 

Add internal function `_calculate_interval_velocity_surfaces`. This is called in the `_check_fix_surfaces` function. A public generator method `interval_velocity_surfaces` is also added to give 'public' access to the surfaces. I think the `_calculate_interval_velocity_surfaces` function could also be useful for potential future features, like velocity model smoothing or clamping velocities to reasonable (physical) limits.

I see that names as well as velocity and slowness surfaces are accessible via generators instead of returning just lists. I am not sure why generators are preferred over lists for these relatively small items, but I think generators are perhaps a little bit less user-friendly as you have to first generate a list if you need the items in a list. Anyway, I also use a generator  in the `interval_velocity_surfaces` method for consistentcy.

I have not updated documentation. Don't know how to do that.

## Checklist

- [x] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [ ] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary  (necessary, but not done)
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [ ] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
