### PR TITLE
BUG: Fix circular import in APS GUI

### DIFF
--- a/src/fmu/tools/__init__.py
+++ b/src/fmu/tools/__init__.py
@@ -7,6 +7,8 @@ import warnings
 
 _logger = logging.getLogger(__name__)
 
+ROXAR = True
+
 from fmu.tools.extract_grid_zone_tops_etc import extract_grid_zone_tops  # noqa
 from fmu.tools.qcforward.qcforward import wellzonation_vs_grid  # noqa
 from fmu.tools.qcproperties.qcproperties import QCProperties  # noqa
@@ -16,7 +18,6 @@ from fmu.tools.nestedhybridgrid.nestedhybrid import create_nested_hybrid_grid  #
 from fmu.tools.nestedhybridgrid.nestedhybrid import nnc_to_flowsimulator_input  # noqa
 from fmu.tools.nestedhybridgrid.nestedhybrid import nnc_to_gridproperty  # noqa
 
-ROXAR = True
 try:
     import rmsapi  # type: ignore # noqa
 except ImportError:


### PR DESCRIPTION
Resolves #462 

Have tested this in RMS and the errors are now gone in APS GUI.
<img width="1355" height="863" alt="2026-07-01_8-31-04 PM" src="https://github.com/user-attachments/assets/56a890da-2f09-475f-9c43-83c9fdb5b897" />

Also ran fmu-tools test suite in RMS env and all passed:
```text
285 passed, 17 skipped, 8 xfailed, 200 warnings in 43.51s
```

## Checklist

- [ ] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
