### PR TITLE
TYP: Fixed tmpdir fixtures for test_rmsvolumetrics

### DIFF
--- a/tests/rms/test_rmsvolumetrics.py
+++ b/tests/rms/test_rmsvolumetrics.py
@@ -7,6 +7,7 @@ from unittest import mock
 
 import pandas as pd
 import pytest
+from _pytest.compat import LEGACY_PATH
 
 from fmu.tools.rms import volumetrics
 
@@ -133,7 +134,7 @@ TESTDIR = Path(__file__).parent / "volumetricsdata"
     ],
 )
 def test_rms_to_volumetrics(
-    multiline_str: str, filename: str, expected_df: pd.DataFrame, tmpdir: Path
+    multiline_str: str, filename: str, expected_df: pd.DataFrame, tmpdir: LEGACY_PATH
 ) -> None:
     tmpdir.chdir()
     Path(filename).write_text(multiline_str)
@@ -178,7 +179,7 @@ def test_volumetrics() -> None:
     assert "FAULTSEGMENT" in dframe.columns
 
 
-def test_merge_rms_volumetrics_explicit(tmpdir: Path) -> None:
+def test_merge_rms_volumetrics_explicit(tmpdir: LEGACY_PATH) -> None:
     """Test finding and merging of multiple RMS volumetrics files"""
     tmpdir.chdir()
     Path("test_oil_1.txt").write_text("Zone  Bulk\nUpper  1.0")
@@ -207,7 +208,7 @@ def test_merge_rms_volumetrics_explicit(tmpdir: Path) -> None:
         volumetrics.merge_rms_volumetrics("foo")
 
 
-def test_merge_rms_volumetrics_mixedcols(tmpdir: Path) -> None:
+def test_merge_rms_volumetrics_mixedcols(tmpdir: LEGACY_PATH) -> None:
     """Bulk in one file and Pore in another, just means we don't get all columns"""
     tmpdir.chdir()
     Path("test_oil_1.txt").write_text("Zone  Bulk\nUpper  1.0")
@@ -231,7 +232,7 @@ def test_commandlineclient_installed() -> None:
 
 
 @pytest.mark.integration
-def test_commandlineclient(tmpdir: Path) -> None:
+def test_commandlineclient(tmpdir: LEGACY_PATH) -> None:
     """Test endpoint"""
 
     tmpdir.chdir()


### PR DESCRIPTION
Resolves #472 

Fixed `test_rmsvolumetrics.py` by annotating the `tmpdir` fixture as `_pytest.compat.LEGACY_PATH` instead of `pathlib.Path`. That matches pytest’s legacy `tmpdir` object, which does provide `.chdir()`, and follows the existing pattern used in neighboring RMS tests.

## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
