### PR TITLE
ENH: Add method to write nnc table to file

### DIFF
--- a/docs/nestedhybridgrid.rst
+++ b/docs/nestedhybridgrid.rst
@@ -53,8 +53,8 @@ The example here runs within RMS, but similar workflows can be created for file 
     # store nested grid with properties in RMS
     nhg.to_rms(project, "NestedHybrid")
 
-    # write the NNC pandas to disk; this will be applied for computing NNC's in the next script
-    nhg.nnc_table.to_csv("path_to_some_csv_file.csv", index=False)
+    # write the NNC table to disk; this will be applied for computing NNC's in the next script
+    nhg.write_nnc_table("path_to_some_csv_file.csv")
 
 
 The next step is to do a rescaling from the original geogrid to the merged grid

--- a/src/fmu/tools/nestedhybridgrid/nestedhybrid.py
+++ b/src/fmu/tools/nestedhybridgrid/nestedhybrid.py
@@ -430,6 +430,10 @@ class NestedHybridGrid:
             self._nnc_table = self._compute_nnc_table()
         return self._nnc_table
 
+    def write_nnc_table(self, filename: str | os.PathLike[str]) -> None:
+        """Write the NNC mapping table to CSV."""
+        self.nnc_table.to_csv(filename, index=False)
+
     def _compute_nnc_table(self) -> pd.DataFrame:
         """Compute the NNC mapping table."""
         return _compute_nnc_table(

--- a/src/fmu/tools/nestedhybridgrid/nestedhybrid.py
+++ b/src/fmu/tools/nestedhybridgrid/nestedhybrid.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import logging
 import warnings
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, Self, TypeAlias
 
 import numpy as np
@@ -430,9 +431,11 @@ class NestedHybridGrid:
             self._nnc_table = self._compute_nnc_table()
         return self._nnc_table
 
-    def write_nnc_table(self, filename: str | os.PathLike[str]) -> None:
+    def write_nnc_table(self, filename: str | Path) -> None:
         """Write the NNC mapping table to CSV."""
-        self.nnc_table.to_csv(filename, index=False)
+        output_path = Path(filename)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        self.nnc_table.to_csv(output_path, index=False)
 
     def _compute_nnc_table(self) -> pd.DataFrame:
         """Compute the NNC mapping table."""

--- a/tests/nestedhybridgrid/test_nestedhybrid.py
+++ b/tests/nestedhybridgrid/test_nestedhybrid.py
@@ -445,11 +445,7 @@ class TestNestedHybridGridClass:
 
     def test_write_nnc_table_writes_csv_without_index(self, tmp_path):
         """NNC table can be written to CSV without the pandas index."""
-        grid = xtgeo.create_box_grid((3, 3, 1))
-
-        region = xtgeo.GridProperty(grid, name="REGION", discrete=True, values=0)
-        region.values[1, 1, 0] = 1
-
+        grid, region, _ = _make_box_grid_with_region(dimension=(3, 3, 1))
         nhg = NestedHybridGrid(coarse_grid=grid, region=region, refinement=(2, 2, 2))
         outfile = tmp_path / "nnc_table.csv"
 
@@ -461,9 +457,7 @@ class TestNestedHybridGridClass:
 
     def test_write_nnc_table_creates_output_directories(self, tmp_path):
         """Missing parent directories are created before writing the table."""
-        grid = xtgeo.create_box_grid((3, 3, 1))
-        region = xtgeo.GridProperty(grid, name="REGION", discrete=True, values=0)
-        region.values[1, 1, 0] = 1
+        grid, region, _ = _make_box_grid_with_region(dimension=(3, 3, 1))
         nhg = NestedHybridGrid(coarse_grid=grid, region=region, refinement=(2, 2, 2))
         outfile = tmp_path / "nested" / "output" / "nnc_table.csv"
 

--- a/tests/nestedhybridgrid/test_nestedhybrid.py
+++ b/tests/nestedhybridgrid/test_nestedhybrid.py
@@ -443,6 +443,22 @@ class TestNestedHybridGridClass:
         # right neighbor → connects to I+ face of refined patch
         assert _has_single_row(i1=3, j1=2, k1=1, i2=6, j2=2, k2=1, direction="I-")
 
+    def test_write_nnc_table_writes_csv_without_index(self, tmp_path):
+        """NNC table can be written to CSV without the pandas index."""
+        grid = xtgeo.create_box_grid((3, 3, 1))
+
+        region = xtgeo.GridProperty(grid, name="REGION", discrete=True, values=0)
+        region.values[1, 1, 0] = 1
+
+        nhg = NestedHybridGrid(coarse_grid=grid, region=region, refinement=(2, 2, 2))
+        outfile = tmp_path / "nnc_table.csv"
+
+        nhg.write_nnc_table(outfile)
+
+        written = pd.read_csv(outfile)
+        assert "Unnamed: 0" not in written.columns
+        pd.testing.assert_frame_equal(written, nhg.nnc_table, check_dtype=False)
+
     def test_inactive_neighbor_excluded_from_nnc(self):
         """Inactive coarse neighbor cells should not appear in the NNC table.
 

--- a/tests/nestedhybridgrid/test_nestedhybrid.py
+++ b/tests/nestedhybridgrid/test_nestedhybrid.py
@@ -459,6 +459,18 @@ class TestNestedHybridGridClass:
         assert "Unnamed: 0" not in written.columns
         pd.testing.assert_frame_equal(written, nhg.nnc_table, check_dtype=False)
 
+    def test_write_nnc_table_creates_output_directories(self, tmp_path):
+        """Missing parent directories are created before writing the table."""
+        grid = xtgeo.create_box_grid((3, 3, 1))
+        region = xtgeo.GridProperty(grid, name="REGION", discrete=True, values=0)
+        region.values[1, 1, 0] = 1
+        nhg = NestedHybridGrid(coarse_grid=grid, region=region, refinement=(2, 2, 2))
+        outfile = tmp_path / "nested" / "output" / "nnc_table.csv"
+
+        nhg.write_nnc_table(outfile)
+
+        assert outfile.is_file()
+
     def test_inactive_neighbor_excluded_from_nnc(self):
         """Inactive coarse neighbor cells should not appear in the NNC table.
 


### PR DESCRIPTION
Resolves #469 

Implemented a convenience method for writing the nested hybrid grid NNC table to disk.

## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [ ] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
