### PR TITLE
FIX: Only emit FutureWarning when method is not given

### DIFF
--- a/src/fmu/tools/domainconversion/dconvert.py
+++ b/src/fmu/tools/domainconversion/dconvert.py
@@ -945,7 +945,7 @@ class DomainConversion:
         zmin: float | None = None,
         zmax: float | None = None,
         undefined: float = -999.25,
-        method: Literal["fft", "linear"] = "linear",
+        method: Literal["fft", "linear"] | None = None,
     ) -> xtgeo.Cube:
         """Depth convert a cube (time to depth).
 
@@ -964,13 +964,15 @@ class DomainConversion:
             for technical reasons.
 
         """
-        warnings.warn(
-            "Default trace interpolation method will be set to 'fft' in the near "
-            "future. Explicitely set method='linear' to keep the same results: "
-            "vm.depth_convert_cube(incube, zinc, zmin, zmax, method='linear').",
-            category=FutureWarning,
-            stacklevel=2,
-        )
+        if method is None:
+            warnings.warn(
+                "Default trace interpolation method will be set to 'fft' in the near "
+                "future. Explicitly set method='linear' to keep the same results: "
+                "vm.depth_convert_cube(incube, zinc, zmin, zmax, method='linear').",
+                category=FutureWarning,
+                stacklevel=2,
+            )
+            method = "linear"
 
         return self._domain_convert_cube(
             incube,
@@ -989,7 +991,7 @@ class DomainConversion:
         tmin: float | None = None,
         tmax: float | None = None,
         undefined: float = -999.25,
-        method: Literal["fft", "linear"] = "linear",
+        method: Literal["fft", "linear"] | None = None,
     ) -> xtgeo.Cube:
         """Time convert a cube (depth to time).
 
@@ -1008,13 +1010,15 @@ class DomainConversion:
             reasons.
 
         """
-        warnings.warn(
-            "Default trace interpolation method will be set to 'fft' in the near "
-            "future. Explicitely set method='linear' to keep the same results: "
-            "vm.time_convert_cube(incube, tinc, tmin, tmax, method='linear').",
-            category=FutureWarning,
-            stacklevel=2,
-        )
+        if method is None:
+            warnings.warn(
+                "Default trace interpolation method will be set to 'fft' in the near "
+                "future. Explicitly set method='linear' to keep the same results: "
+                "vm.time_convert_cube(incube, tinc, tmin, tmax, method='linear').",
+                category=FutureWarning,
+                stacklevel=2,
+            )
+            method = "linear"
 
         return self._domain_convert_cube(
             incube,

--- a/tests/domainconversion/test_domainconversion.py
+++ b/tests/domainconversion/test_domainconversion.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import warnings
 from typing import Any, Literal
 
 import numpy as np
@@ -208,6 +209,53 @@ def test_generate_simple_velocube(
     assert velocube.xlines == smallcube.xlines
 
     plot_section(velocube, simplesurfs, title="Avg Velocity cube in T")
+
+
+def test_depth_convert_cube_warns_only_when_method_is_omitted(
+    smallcube: xtgeo.Cube,
+    simplesurfs: tuple[list[xtgeo.RegularSurface], list[xtgeo.RegularSurface]],
+) -> None:
+    """FutureWarning should only be emitted when method is not explicitly set."""
+
+    dc = DomainConversion(*simplesurfs)
+
+    with pytest.warns(FutureWarning, match="Default trace interpolation method"):
+        dc.depth_convert_cube(smallcube, zinc=1.0, zmin=0.0, zmax=100.0)
+
+    with warnings.catch_warnings(record=True) as recorded:
+        dc.depth_convert_cube(
+            smallcube, zinc=1.0, zmin=0.0, zmax=100.0, method="linear"
+        )
+
+    assert not any(
+        isinstance(w.message, FutureWarning)
+        and "Default trace interpolation method" in str(w.message)
+        for w in recorded
+    )
+
+
+def test_time_convert_cube_warns_only_when_method_is_omitted(
+    smallcube: xtgeo.Cube,
+    simplesurfs: tuple[list[xtgeo.RegularSurface], list[xtgeo.RegularSurface]],
+) -> None:
+    """FutureWarning should only be emitted when method is not explicitly set."""
+
+    dc = DomainConversion(*simplesurfs)
+    depthcube = dc.depth_convert_cube(
+        smallcube, zinc=1.0, zmin=0.0, zmax=100.0, method="linear"
+    )
+
+    with pytest.warns(FutureWarning, match="Default trace interpolation method"):
+        dc.time_convert_cube(depthcube, tinc=1.0, tmin=0.0, tmax=100.0)
+
+    with warnings.catch_warnings(record=True) as recorded:
+        dc.time_convert_cube(depthcube, tinc=1.0, tmin=0.0, tmax=100.0, method="linear")
+
+    assert not any(
+        isinstance(w.message, FutureWarning)
+        and "Default trace interpolation method" in str(w.message)
+        for w in recorded
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Resolves #493 


## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
