### PR TITLE
docs: fix typos in comments, docstrings and CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ If you are proposing a feature:
 
 ## Code standards
 
-It is required to be complient to code standards. A summary:
+It is required to be compliant to code standards. A summary:
 
 ### Formatted with ruff
 

--- a/src/fmu/tools/_common.py
+++ b/src/fmu/tools/_common.py
@@ -55,7 +55,7 @@ class _QCCommon(object):
 
 
 def preserve_cwd(func):
-    """Decorator to return to orginal CWD, applied in testing"""
+    """Decorator to return to original CWD, applied in testing"""
 
     @wraps(func)
     def wrapper(*args, **kwargs):

--- a/src/fmu/tools/qcforward/_grid_statistics.py
+++ b/src/fmu/tools/qcforward/_grid_statistics.py
@@ -38,7 +38,7 @@ class GridStatistics(QCForward):
         data: Union[dict, str],
         project: Optional[Union[object, str]] = None,
     ) -> None:
-        """Main routine for evaulating if statistics from 3D grids is
+        """Main routine for evaluating if statistics from 3D grids is
         within user specified thresholds.
 
         The routine depends on existing fmu.tools functionality for
@@ -85,7 +85,7 @@ class GridStatistics(QCForward):
 
             selectors, calculation = self._get_selecors_and_calculation(action)
 
-            # Create datframe with statistics
+            # Create dataframe with statistics
             dframe = qcp.get_grid_statistics(project=project, data=data_upd)
 
             # Get value from statistics for given property and selectors
@@ -172,7 +172,7 @@ class GridStatistics(QCForward):
     def _get_selecors_and_calculation(action: dict) -> tuple:
         """
         Get selectors and selected calculation from the action.
-        If a discrete property has been input it is added to the selctors.
+        If a discrete property has been input it is added to the selectors.
         If calculation is not specified a default is set.
         """
         selectors = action.get("selectors", {})
@@ -189,7 +189,7 @@ class GridStatistics(QCForward):
         selectors: Optional[dict] = None,
     ) -> float:
         """
-        Retrive statistical value from the property statistic dataframe
+        Retrieve statistical value from the property statistic dataframe
         """
 
         dframe = dframe[dframe["PROPERTY"] == prop].copy()

--- a/src/fmu/tools/qcforward/_wellzonation_vs_grid.py
+++ b/src/fmu/tools/qcforward/_wellzonation_vs_grid.py
@@ -66,7 +66,7 @@ class _LocalData:
 
 class WellZonationVsGrid(QCForward):
     def run(self, data, reuse=False, project=None):
-        """Main routine for evaulating well zonation match in 3D grids.
+        """Main routine for evaluating well zonation match in 3D grids.
 
         The routine depends on existing XTGeo functions for this purpose
 

--- a/src/fmu/tools/qcproperties/_aggregate_df.py
+++ b/src/fmu/tools/qcproperties/_aggregate_df.py
@@ -12,7 +12,7 @@ QCC = _QCCommon()
 class PropertyAggregation:
     """
     Class for extracting statistics from a property dataframe.
-    Statistics for multiple properties can be calculated simultaneosly. The
+    Statistics for multiple properties can be calculated simultaneously. The
     aggregation methods and statistics are based on the property type.
     Selectors can be used to extract statistics per value in discrete properties.
     """
@@ -65,7 +65,7 @@ class PropertyAggregation:
     # ==================================================================================
 
     def _disc_aggregations(self):
-        """Statistical aggregations to extract from continous data"""
+        """Statistical aggregations to extract from discrete data"""
         return [
             ("Count", "count"),
             (
@@ -79,7 +79,7 @@ class PropertyAggregation:
         ]
 
     def _cont_aggregations(self, dframe=None):
-        """Statistical aggregations to extract from discrete data"""
+        """Statistical aggregations to extract from continuous data"""
         return [
             ("Avg", np.mean),
             ("Stddev", np.std),
@@ -105,7 +105,7 @@ class PropertyAggregation:
 
     def _calculate_continous_statistics(self, selector_combo_list):
         """
-        Calculate statistics for continous properties.
+        Calculate statistics for continuous properties.
         Returns a pandas dataframe.
         """
 

--- a/src/fmu/tools/qcproperties/_config_parser.py
+++ b/src/fmu/tools/qcproperties/_config_parser.py
@@ -70,7 +70,7 @@ class ConfigParser:
 
     @property
     def aggregation_controls(self) -> dict:
-        """Attribute to use for statisticts aggregation"""
+        """Attribute to use for statistics aggregation"""
         return self._aggregation_controls
 
     @property
@@ -139,7 +139,7 @@ class ConfigParser:
             if "pfile" in values:
                 self._data_loading_input["pfiles"][name] = values["pfile"]
 
-            # support using a selector prop as filter. If the selctor
+            # support using a selector prop as filter. If the selector
             # has filters specified in its values, they will be ignored
             if name in self._prop2df_controls["filters"]:
                 QCC.give_warn(

--- a/src/fmu/tools/qcproperties/_grid2df.py
+++ b/src/fmu/tools/qcproperties/_grid2df.py
@@ -12,8 +12,9 @@ QCC = _QCCommon()
 
 class GridProps2df:
     """
-    Class responsible for generating a property dataframe from grid prperties, and
-    providing control arguments for the statisics extraction using PropertyAggregation()
+    Class responsible for generating a property dataframe from grid properties, and
+    providing control arguments for the statistics extraction using
+    PropertyAggregation()
     """
 
     def __init__(self, project: Optional[object], data: dict, xtgdata: QCData):
@@ -40,7 +41,7 @@ class GridProps2df:
 
     @property
     def property_type(self) -> Optional[str]:
-        """Property type (continous/discrete)"""
+        """Property type (continuous/discrete)"""
         return self._property_type
 
     @property
@@ -107,7 +108,7 @@ class GridProps2df:
     def _check_and_set_property_type(self):
         """
         Use XTGeo to check that selectors are discrete, and also
-        check if input properties are continous or discrete.
+        check if input properties are continuous or discrete.
         Raise errors if not desired format.
         """
         # check that all selectors are discrete
@@ -134,12 +135,12 @@ class GridProps2df:
         # Set attribute used to control aggregation method
         discrete = xtgprops[0].isdiscrete
         QCC.print_debug(
-            f"{'Discrete' if discrete else 'Continous'} properties in input"
+            f"{'Discrete' if discrete else 'Continuous'} properties in input"
         )
         self._property_type = "DISC" if discrete else "CONT"
 
     def _codes_to_codenames(self):
-        """Replace codes in dicrete parameters with codenames"""
+        """Replace codes in discrete parameters with codenames"""
         for param in self._controls["unique_parameters"]:
             xtg_prop = self._xtgdata.gridprops.get_prop_by_name(param)
 

--- a/src/fmu/tools/qcproperties/_well2df.py
+++ b/src/fmu/tools/qcproperties/_well2df.py
@@ -13,7 +13,8 @@ QCC = _QCCommon()
 class WellLogs2df:
     """
     Class responsible for generating a property dataframe from well logs, and
-    providing control arguments for the statisics extraction using PropertyAggregation()
+    providing control arguments for the statistics extraction using
+    PropertyAggregation()
     """
 
     def __init__(
@@ -47,7 +48,7 @@ class WellLogs2df:
 
     @property
     def property_type(self) -> Optional[str]:
-        """Property type (continous/discrete)"""
+        """Property type (continuous/discrete)"""
         return self._property_type
 
     @property
@@ -117,7 +118,7 @@ class WellLogs2df:
     def _check_logs_and_set_property_type(self):
         """
         Use XTGeo to check that selectors are discrete, and also
-        check if input properties are continous or discrete.
+        check if input properties are continuous or discrete.
         Raise errors if not desired format.
         """
         # check that all selectors are discrete
@@ -138,12 +139,12 @@ class WellLogs2df:
         # Set attribute used to control aggregation method
         discrete = self._wells[0].isdiscrete(properties[0])
         QCC.print_debug(
-            f"{'Discrete' if discrete else 'Continous'} properties in input"
+            f"{'Discrete' if discrete else 'Continuous'} properties in input"
         )
         self._property_type = "DISC" if discrete else "CONT"
 
     def _codes_to_codenames(self):
-        """Replace codes in dicrete parameters with codenames"""
+        """Replace codes in discrete parameters with codenames"""
         for param in self._controls["unique_parameters"]:
             if self._wells[0].isdiscrete(param):
                 codes = self._wells[0].get_logrecord(param).copy()

--- a/src/fmu/tools/qcproperties/qcproperties.py
+++ b/src/fmu/tools/qcproperties/qcproperties.py
@@ -20,7 +20,7 @@ class QCProperties:
     The QCProperties class consists of a set of methods for extracting
     property statistics from 3D Grids, Raw and Blocked wells.
 
-    Statistics can be collected from either discrete or continous properties.
+    Statistics can be collected from either discrete or continuous properties.
     Dependent on the property different statistics are collected.
 
     The methods for statistics extraction can be run individually, or a
@@ -103,7 +103,7 @@ class QCProperties:
         if not all(ptype == self._proptypes_all[0] for ptype in self._proptypes_all):
             QCC.give_warn(
                 "Merging statistics dataframes from different property types "
-                "(continous/discrete). Is this intentional?"
+                "(continuous/discrete). Is this intentional?"
             )
 
     def _adjust_id_if_duplicate(self, run_id: str) -> str:
@@ -122,7 +122,7 @@ class QCProperties:
         self, statistics: PropertyAggregation, source: str, run_id: str
     ):
         """
-        Set source and id column of statistics datframe, and different
+        Set source and id column of statistics dataframe, and different
         class attributes.
         """
         run_id = self._adjust_id_if_duplicate(run_id)

--- a/src/fmu/tools/rms/volumetrics.py
+++ b/src/fmu/tools/rms/volumetrics.py
@@ -35,7 +35,7 @@ def merge_rms_volumetrics(filebase: str, rmsrealsuffix: str = "_1") -> pd.DataFr
         set.intersection(*[set(frame.columns) for frame in volframes])
     )
 
-    # Merge all frames on the commmon columns:
+    # Merge all frames on the common columns:
     merged_dframe = pd.DataFrame(columns=common_columns)
     for frame in volframes:
         merged_dframe = pd.merge(merged_dframe, frame, on=common_columns, how="outer")

--- a/src/fmu/tools/utilities/sample_attributes.py
+++ b/src/fmu/tools/utilities/sample_attributes.py
@@ -101,7 +101,7 @@ def sample_attributes_for_sim2seis(
     position: tuple[str, Position] = ("", Position.CENTER),
     **kwargs: Any,
 ) -> pd.DataFrame:
-    """Sample attributes on grid resolution as poinst sets.
+    """Sample attributes on grid resolution as points sets.
 
     This usage is for setting attributes on grid resolution, e.g. a seismic attribute
     (from a map) combined with a region parameter from the grid.
@@ -113,7 +113,7 @@ def sample_attributes_for_sim2seis(
         attribute: The seismic (or custom) map/surface to sample the attribute from.
         attribute_error: The error to apply to the attribute (optional).
             Shall be absolute (positive) values. If the user wants to apply a polygons
-            with different error values, the user can ise surface-polygons functions
+            with different error values, the user can use surface-polygons functions
             in xtgeo to achieve this.
         attribute_error_minimum: The minimum error to apply to the attribute (optional).
         region: The region parameter to sample from the grid (optional).
@@ -127,7 +127,7 @@ def sample_attributes_for_sim2seis(
         **kwargs: Additional keywords (developer settings).
 
     Returns:
-        pd.Dataframe: Points with the sampled attributes and attributes combined.
+        pd.DataFrame: Points with the sampled attributes and attributes combined.
     """
     logger.info("Sampling attributes on grid resolution as points set.")
 


### PR DESCRIPTION
## Summary

Spelling/wording fixes in comments, docstrings and `CONTRIBUTING.md`. 11 files, 33 insertions / 31 deletions. `ruff check .` and `ruff format --check` both pass (and passed on the pristine base, so no regression).

### From the report

- **src/fmu/tools/rms/volumetrics.py**: `commmon` -> `common`
- **src/fmu/tools/qcproperties/_aggregate_df.py**: `simultaneosly` -> `simultaneously`; `continous` -> `continuous`
- **src/fmu/tools/qcproperties/_config_parser.py**: `statisticts` -> `statistics`; `selctor` -> `selector`
- **src/fmu/tools/qcproperties/_well2df.py**: `statisics` -> `statistics`; `continous` -> `continuous`; `Continous` -> `Continuous`; `dicrete` -> `discrete`
- **src/fmu/tools/qcproperties/_grid2df.py**: `prperties` -> `properties`; `statisics` -> `statistics`
- **src/fmu/tools/qcforward/_grid_statistics.py**: `evaulating` -> `evaluating`; `datframe` -> `dataframe`; `selctors` -> `selectors`; `Retrive` -> `Retrieve`
- **src/fmu/tools/utilities/sample_attributes.py**: `poinst` -> `points`; `pd.Dataframe` -> `pd.DataFrame`

### :warning: One change alters meaning, not spelling - please review

In `qcproperties/_aggregate_df.py` the two aggregation docstrings are **swapped**:

- `_disc_aggregations()` (called only from `_calculate_discrete_fractions`, returns `Count` / `Sum_Weight`) documented itself as *"aggregations to extract from continous data"*
- `_cont_aggregations()` (called only from `_calculate_continous_statistics`, returns `Avg` / `Stddev` / `P10` / `P90` / `Min` / `Max`) documented itself as *"aggregations to extract from discrete data"*

They are now `discrete data` and `continuous data` respectively.

### Two runtime strings changed

`_well2df.py` and `_grid2df.py` both emit `QCC.print_debug(f"{'Discrete' if discrete else 'Continous'} properties in input")`. That is a debug log line only; nothing in `tests/` asserts on it.

### Additional typos found while verifying (not in the original report)

- **src/fmu/tools/qcforward/_wellzonation_vs_grid.py**: `evaulating` -> `evaluating`
- **src/fmu/tools/qcproperties/qcproperties.py**: `continous` -> `continuous` (x2); `datframe` -> `dataframe`
- **src/fmu/tools/_common.py**: `orginal` -> `original`
- **src/fmu/tools/utilities/sample_attributes.py**: `the user can ise` -> `the user can use`
- **CONTRIBUTING.md**: `complient` -> `compliant`
- `_well2df.py` / `_grid2df.py`: the `continous` -> `continuous` and `dicrete` -> `discrete` fixes were applied to every non-identifier occurrence in those two files, not only the cited lines

### Deliberately left alone

- `_calculate_continous_statistics` and `_get_selecors_and_calculation` - misspelled but they are method names; renaming them is an API change, not a typo fix.
- `tests/qcproperties/test_qcproperties.py::test_continous_properties` - a test identifier.
- `docs/qcproperties.rst` and `docs/qcforward/grid_statistics.inc` still contain `continous` in prose (9 occurrences) and `whith` at qcproperties.rst:79; `continous_stats.csv` there is an example filename. Happy to fix the docs in this PR or a follow-up, whichever you prefer.

### Note on two rewrapped lines

`_grid2df.py:16` and `_well2df.py:16` were exactly 88 characters; `statisics` -> `statistics` pushed them to 89 and tripped ruff E501, so `PropertyAggregation()` moved to its own continuation line.

No functional changes.